### PR TITLE
fix: rpc sometime not awake cause rpc slow

### DIFF
--- a/packages/services/rpc/src/handler.rs
+++ b/packages/services/rpc/src/handler.rs
@@ -33,7 +33,10 @@ impl<BE, HE> ConnectionHandler<BE, HE> for RpcHandler {
                 if msg.is_answer() {
                     let req_id = msg.req_id().expect("Should has");
                     if let Some(tx) = rpc_queue.take_request(req_id) {
+                        log::info!("[RpcHandler] on answer {}", msg.cmd);
                         tx.try_send(Ok(msg)).print_error("Should send");
+                    } else {
+                        log::warn!("[RpcHandler] on answer {} without tx", msg.cmd);
                     }
                 } else {
                     self.tx.try_send(msg).print_error("Should send");


### PR DESCRIPTION
Old check logic of awake or not is based on queue length == 1. But it not correct after implemented Reliable msg mechanism. In case of big msg, Reliable Mechanism will split msg into number of small pkts, then queue length will immediate increased  from 0 to greater than 1 before call awake checker