### PR TITLE
feat: node_alias service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "packages/services/pub_sub",
     "packages/services/rpc",
     "packages/services/virtual_socket",
+    "packages/services/node_alias",
     "packages/transports/vnet",
     "packages/transports/tcp",
     "packages/transports/udp",

--- a/packages/integration_tests/src/lib.rs
+++ b/packages/integration_tests/src/lib.rs
@@ -1,4 +1,5 @@
 mod key_value;
+mod node_alias;
 mod pubsub;
 mod rpc;
 mod virtual_socket;

--- a/packages/integration_tests/src/node_alias.rs
+++ b/packages/integration_tests/src/node_alias.rs
@@ -1,0 +1,162 @@
+#[cfg(test)]
+mod tests {
+    use async_std::prelude::FutureExt;
+    use async_std::task::JoinHandle;
+    use atm0s_sdn::{convert_enum, NetworkPlane, NetworkPlaneConfig};
+    use atm0s_sdn::{KeyValueBehavior, KeyValueBehaviorEvent, KeyValueHandlerEvent, KeyValueSdk, KeyValueSdkEvent};
+    use atm0s_sdn::{LayersSpreadRouterSyncBehavior, LayersSpreadRouterSyncBehaviorEvent, LayersSpreadRouterSyncHandlerEvent};
+    use atm0s_sdn::{ManualBehavior, ManualBehaviorConf, ManualBehaviorEvent, ManualHandlerEvent};
+    use atm0s_sdn::{NodeAddr, NodeAddrBuilder, NodeId, PubsubServiceBehaviour, PubsubServiceBehaviourEvent, PubsubServiceHandlerEvent};
+    use atm0s_sdn::{NodeAliasBehavior, NodeAliasId, NodeAliasResult, NodeAliasSdk, SharedRouter};
+    use atm0s_sdn::{OptionUtils, SystemTimer};
+    use atm0s_sdn_transport_vnet::VnetEarth;
+    use std::{sync::Arc, time::Duration, vec};
+
+    #[derive(convert_enum::From, convert_enum::TryInto)]
+    enum ImplBehaviorEvent {
+        Pubsub(PubsubServiceBehaviourEvent),
+        KeyValue(KeyValueBehaviorEvent),
+        RouterSync(LayersSpreadRouterSyncBehaviorEvent),
+        Manual(ManualBehaviorEvent),
+    }
+
+    #[derive(convert_enum::From, convert_enum::TryInto)]
+    enum ImplHandlerEvent {
+        Pubsub(PubsubServiceHandlerEvent),
+        KeyValue(KeyValueHandlerEvent),
+        RouterSync(LayersSpreadRouterSyncHandlerEvent),
+        Manual(ManualHandlerEvent),
+    }
+
+    #[derive(convert_enum::From, convert_enum::TryInto)]
+    enum ImplSdkEvent {
+        KeyValue(KeyValueSdkEvent),
+    }
+
+    async fn run_node(vnet: Arc<VnetEarth>, node_id: NodeId, seeds: Vec<NodeAddr>) -> (NodeAliasSdk, NodeAddr, JoinHandle<()>) {
+        log::info!("Run node {} connect to {:?}", node_id, seeds);
+        let node_addr = Arc::new(NodeAddrBuilder::new(node_id));
+        let transport = Box::new(atm0s_sdn_transport_vnet::VnetTransport::new(vnet, node_addr.addr()));
+        let timer = Arc::new(SystemTimer());
+
+        let router = SharedRouter::new(node_id);
+        let manual = ManualBehavior::new(ManualBehaviorConf {
+            node_id,
+            node_addr: node_addr.addr(),
+            seeds,
+            local_tags: vec![],
+            connect_tags: vec![],
+        });
+
+        let router_sync_behaviour = LayersSpreadRouterSyncBehavior::new(router.clone());
+        let kv_sdk = KeyValueSdk::new();
+        let kv_behaviour = KeyValueBehavior::new(node_id, 1000, Some(Box::new(kv_sdk.clone())));
+        let (pubsub_behavior, pubsub_sdk) = PubsubServiceBehaviour::new(node_id, timer.clone());
+        let (node_alias_behavior, node_alias_sdk) = NodeAliasBehavior::new(node_id, pubsub_sdk);
+
+        let mut plane = NetworkPlane::<ImplBehaviorEvent, ImplHandlerEvent, ImplSdkEvent>::new(NetworkPlaneConfig {
+            node_id,
+            tick_ms: 100,
+            behaviors: vec![
+                Box::new(pubsub_behavior),
+                Box::new(kv_behaviour),
+                Box::new(router_sync_behaviour),
+                Box::new(manual),
+                Box::new(node_alias_behavior),
+            ],
+            transport,
+            timer,
+            router: Arc::new(router.clone()),
+        });
+
+        let join = async_std::task::spawn(async move {
+            plane.started();
+            while let Ok(_) = plane.recv().await {}
+            plane.stopped();
+        });
+
+        (node_alias_sdk, node_addr.addr(), join)
+    }
+
+    /// Testing local alias
+    #[async_std::test]
+    async fn local_node() {
+        let vnet = Arc::new(VnetEarth::default());
+        let (sdk, _addr, join) = run_node(vnet, 1, vec![]).await;
+
+        async_std::task::sleep(Duration::from_millis(300)).await;
+        let node_alias: NodeAliasId = 1000.into();
+
+        sdk.register(node_alias.clone());
+
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromLocal));
+
+        join.cancel().await.print_none("Should cancel join");
+    }
+
+    /// Testing remote alias with scan
+    #[async_std::test]
+    async fn remote_node_scan() {
+        let vnet = Arc::new(VnetEarth::default());
+        let (sdk1, addr1, join1) = run_node(vnet.clone(), 1, vec![]).await;
+        async_std::task::sleep(Duration::from_millis(300)).await;
+
+        let node_alias: NodeAliasId = 1000.into();
+        sdk1.register(node_alias.clone());
+
+        let (sdk2, _addr2, join2) = run_node(vnet, 2, vec![addr1]).await;
+        //Need to wait pub-sub ready
+        async_std::task::sleep(Duration::from_millis(2000)).await;
+
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk2.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromScan(1)));
+
+        join1.cancel().await.print_none("Should cancel join");
+        join2.cancel().await.print_none("Should cancel join");
+    }
+
+    /// Testing remote alias
+    #[async_std::test]
+    async fn remote_node_find() {
+        let vnet = Arc::new(VnetEarth::default());
+        let (sdk1, addr1, join1) = run_node(vnet.clone(), 1, vec![]).await;
+        let (sdk2, _addr2, join2) = run_node(vnet, 2, vec![addr1]).await;
+
+        async_std::task::sleep(Duration::from_millis(300)).await;
+        let node_alias: NodeAliasId = 1000.into();
+
+        //Need to wait pub-sub ready
+        async_std::task::sleep(Duration::from_millis(2000)).await;
+
+        //we will register after pubsub ready => it will be registered on remote node
+        sdk1.register(node_alias.clone());
+
+        //wait for remote register done
+        async_std::task::sleep(Duration::from_millis(300)).await;
+
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk2.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromHint(1)));
+
+        join1.cancel().await.print_none("Should cancel join");
+        join2.cancel().await.print_none("Should cancel join");
+    }
+}

--- a/packages/integration_tests/src/node_alias.rs
+++ b/packages/integration_tests/src/node_alias.rs
@@ -98,6 +98,16 @@ mod tests {
         );
         assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromLocal));
 
+        sdk.unregister(node_alias.clone());
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert!(rx.recv().timeout(Duration::from_millis(100)).await.is_err());
+
         join.cancel().await.print_none("Should cancel join");
     }
 
@@ -123,6 +133,16 @@ mod tests {
             }),
         );
         assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromScan(1)));
+
+        sdk1.unregister(node_alias.clone());
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk2.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert!(rx.recv().timeout(Duration::from_millis(100)).await.is_err());
 
         join1.cancel().await.print_none("Should cancel join");
         join2.cancel().await.print_none("Should cancel join");
@@ -155,6 +175,16 @@ mod tests {
             }),
         );
         assert_eq!(rx.recv().timeout(Duration::from_millis(100)).await.unwrap().unwrap(), Ok(NodeAliasResult::FromHint(1)));
+
+        sdk1.unregister(node_alias.clone());
+        let (tx, rx) = async_std::channel::bounded(1);
+        sdk2.find_alias(
+            node_alias.clone(),
+            Box::new(move |res| {
+                tx.try_send(res).expect("");
+            }),
+        );
+        assert!(rx.recv().timeout(Duration::from_millis(100)).await.is_err());
 
         join1.cancel().await.print_none("Should cancel join");
         join2.cancel().await.print_none("Should cancel join");

--- a/packages/runner/Cargo.toml
+++ b/packages/runner/Cargo.toml
@@ -26,6 +26,7 @@ atm0s-sdn-key-value = { path = "../services/key_value", version = "0.1.7", optio
 atm0s-sdn-pub-sub = { path = "../services/pub_sub", version = "0.1.6", optional = true  }
 atm0s-sdn-rpc = { path = "../services/rpc", version = "0.1.3", optional = true  }
 atm0s-sdn-virtual-socket = { path = "../services/virtual_socket", version = "0.1.0", optional = true  }
+atm0s-sdn-node-alias = { path = "../services/node_alias", version = "0.1.0", optional = true  }
 
 async-trait = { workspace = true }
 futures-util = "0.3"
@@ -41,4 +42,5 @@ spread-router = ["atm0s-sdn-layers-spread-router", "atm0s-sdn-layers-spread-rout
 manual-discovery = ["atm0s-sdn-manual-discovery"]
 rpc = ["atm0s-sdn-rpc"]
 virtual-socket = ["atm0s-sdn-virtual-socket"]
-all = ["transport-udp", "transport-tcp", "transport-compose", "key-value", "pub-sub", "spread-router", "manual-discovery", "rpc", "virtual-socket"]
+node-alias = ["atm0s-sdn-node-alias"]
+all = ["transport-udp", "transport-tcp", "transport-compose", "key-value", "pub-sub", "spread-router", "manual-discovery", "rpc", "virtual-socket", "node-alias"]

--- a/packages/runner/src/lib.rs
+++ b/packages/runner/src/lib.rs
@@ -44,6 +44,9 @@ pub use atm0s_sdn_transport_udp::UdpTransport;
 #[cfg(feature = "transport-compose")]
 pub use atm0s_sdn_transport_compose::compose_transport;
 
+#[cfg(feature = "node-alias")]
+pub use atm0s_sdn_node_alias::{NodeAliasBehavior, NodeAliasSdk, NodeAliasId, NodeAliasError, NodeAliasResult};
+
 pub mod compose_transport_desp {
     pub use futures_util::{select, FutureExt};
     pub use paste::paste;

--- a/packages/services/node_alias/Cargo.toml
+++ b/packages/services/node_alias/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "atm0s-sdn-node-alias"
+version = "0.1.0"
+edition = "2021"
+description = "Node alias service in atm0s-sdn"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+atm0s-sdn-identity = { path = "../../core/identity", version = "0.2.0" }
+atm0s-sdn-router = { path = "../../core/router", version = "0.1.4" }
+atm0s-sdn-utils = { path = "../../core/utils", version = "0.1.1" }
+atm0s-sdn-network = { path = "../../network", version = "0.3.0" }
+atm0s-sdn-pub-sub = { path = "../pub_sub", version = "0.1.6" }
+log = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+async-std = { workspace = true }
+bincode = { workspace = true }
+bytes = "1.5.0"

--- a/packages/services/node_alias/README.md
+++ b/packages/services/node_alias/README.md
@@ -1,0 +1,19 @@
+# atm0s-sdn-node-alias service
+
+This service implement DNS style mechanism, each node will it self register will number of aliases, which usually used on proxy or tunnel server.
+
+## How it works
+
+We using mechanism for avoiding strong sync data between nodes, any nodes can be disconnect and re-join anytime. The mechanism is very simple as described bellow:
+
+- Each time node REGISTER or UNREGISTER with an alias, it broadcast to all nodes about the changed.
+- When a node received REGISTER it store SENDER as LOCATION_HINT
+- When a node want to finding a location for a alias, it will search in local for getting LOCALTION_HINT
+
+    - It ping LOCATION_HINT first for ensuring it still has alias
+    - If don't have LOCATION_HINT or, above ping timeout or node reply with NOT_FOUND, it broadcast SCAN to all other nodes
+    - If a node reply with FOUND, then we got result, if after timeout we dont have FOUND, it mean not found
+
+## Conclusion
+
+Above mechanism very helpful when we have large of aliases and infrequency changed, this can be found in some system like DNS, Tunnel, Proxy. Please don't use this service if you have alisases which changed in very high frequency and high query frequency.

--- a/packages/services/node_alias/README.md
+++ b/packages/services/node_alias/README.md
@@ -1,19 +1,19 @@
-# atm0s-sdn-node-alias service
+# atm0s-sdn Node Alias Service
 
-This service implement DNS style mechanism, each node will it self register will number of aliases, which usually used on proxy or tunnel server.
+This service implements a DNS-style mechanism where each node registers itself along with a number of aliases. These aliases are typically used on proxy or tunnel servers.
 
-## How it works
+## Functionality
 
-We using mechanism for avoiding strong sync data between nodes, any nodes can be disconnect and re-join anytime. The mechanism is very simple as described bellow:
+The mechanism used here helps avoid the need for strong synchronization data between nodes. Any node can disconnect and rejoin at any time. The process is quite straightforward, as explained below:
 
-- Each time node REGISTER or UNREGISTER with an alias, it broadcast to all nodes about the changed.
-- When a node received REGISTER it store SENDER as LOCATION_HINT
-- When a node want to finding a location for a alias, it will search in local for getting LOCALTION_HINT
+- Every time a node registers or unregisters an alias, it broadcasts this change to all other nodes.
+- When a node receives a registration, it stores the sender as the location hint.
+- When a node needs to find a location for an alias, it first checks its local storage for the location hint.
 
-    - It ping LOCATION_HINT first for ensuring it still has alias
-    - If don't have LOCATION_HINT or, above ping timeout or node reply with NOT_FOUND, it broadcast SCAN to all other nodes
-    - If a node reply with FOUND, then we got result, if after timeout we dont have FOUND, it mean not found
+    - It pings the location hint to ensure it still holds the alias.
+    - If there's no location hint, or if the ping times out or the node replies with 'NOT FOUND', the node broadcasts a 'SCAN' request to all other nodes.
+    - If a node replies with 'FOUND', then the result is obtained. However, if after a timeout there's no 'FOUND' response, it means the alias was not found.
 
-## Conclusion
+## Usecase
 
-Above mechanism very helpful when we have large of aliases and infrequency changed, this can be found in some system like DNS, Tunnel, Proxy. Please don't use this service if you have alisases which changed in very high frequency and high query frequency.
+This mechanism proves particularly useful when dealing with a large number of aliases that rarely change. This can be observed in systems like DNS, Tunnels, and Proxies. However, this service should not be used if you have aliases that frequently change and are queried often.

--- a/packages/services/node_alias/src/behavior.rs
+++ b/packages/services/node_alias/src/behavior.rs
@@ -1,0 +1,157 @@
+use std::{sync::Arc, collections::VecDeque};
+
+use async_std::task::JoinHandle;
+use atm0s_sdn_identity::{ConnId, NodeId};
+use atm0s_sdn_network::{
+    behaviour::{BehaviorContext, ConnectionHandler, NetworkBehavior, NetworkBehaviorAction},
+    msg::{TransportMsg, MsgHeader},
+    transport::{ConnectionRejectReason, ConnectionSender, OutgoingConnectionError},
+};
+use atm0s_sdn_pub_sub::{PubsubSdk, Publisher};
+use atm0s_sdn_router::RouteRule;
+use bytes::Bytes;
+use parking_lot::Mutex;
+
+use crate::{handler::NodeAliasHandler, NODE_ALIAS_SERVICE_ID, msg::{BroadcastMsg, SdkControl}, internal::{ServiceInternal, ServiceInternalAction}, sdk::NodeAliasSdk};
+
+const NODE_ALIAS_BROADCAST_CHANNEL: u32 = 0x13ba2c; //TODO hash of "atm0s.node_alias.broadcast"
+
+pub struct NodeAliasBehavior {
+    node_id: NodeId,
+    pubsub_sdk: PubsubSdk,
+    pub_channel: Publisher,
+    pubsub_task: Option<JoinHandle<()>>,
+    incomming_broadcast_queue: Arc<Mutex<VecDeque<(NodeId, BroadcastMsg)>>>,
+    sdk: NodeAliasSdk,
+    internal: Arc<Mutex<ServiceInternal>>,
+}
+
+impl NodeAliasBehavior {
+    pub fn new(node_id: NodeId, pubsub_sdk: PubsubSdk) -> (Self, NodeAliasSdk) {
+        let sdk = NodeAliasSdk::default();
+        let instance = Self {
+            node_id,
+            pub_channel: pubsub_sdk.create_publisher(NODE_ALIAS_BROADCAST_CHANNEL),
+            pubsub_sdk,            
+            pubsub_task: None,
+            incomming_broadcast_queue: Arc::new(Mutex::new(VecDeque::new())),
+            sdk: sdk.clone(),
+            internal: Arc::new(Mutex::new(ServiceInternal::new(node_id))),
+        };
+        
+        (instance, sdk)
+    }
+}
+
+impl<BE, HE, SE> NetworkBehavior<BE, HE, SE> for NodeAliasBehavior {
+    fn service_id(&self) -> u8 {
+        NODE_ALIAS_SERVICE_ID
+    }
+
+    fn on_started(&mut self, ctx: &BehaviorContext, _now_ms: u64) {
+        self.sdk.set_awaker(ctx.awaker.clone());
+        let node_id = self.node_id;
+        let sub_channel = self.pubsub_sdk.create_consumer(NODE_ALIAS_BROADCAST_CHANNEL, None);
+        let awaker = ctx.awaker.clone();
+        let incomming_broadcast_msg = self.incomming_broadcast_queue.clone();
+        self.pubsub_task = Some(async_std::task::spawn(async move {
+            loop {
+                if let Some((_, source, _, msg)) = sub_channel.recv().await {
+                    if source == node_id {
+                        continue;
+                    }
+                    if let Ok(msg) = bincode::deserialize(&msg) {
+                        incomming_broadcast_msg.lock().push_back((source, msg));
+                        awaker.notify();
+                    }
+                }
+            }
+        }));
+    }
+
+    fn on_tick(&mut self, _ctx: &BehaviorContext, now_ms: u64, _interval_ms: u64) {
+        self.internal.lock().on_tick(now_ms);
+    }
+
+    fn on_awake(&mut self, _ctx: &BehaviorContext, now_ms: u64) {
+        let mut incomming_broadcast_msg = self.incomming_broadcast_queue.lock();
+        while let Some((source, msg)) = incomming_broadcast_msg.pop_front() {
+            self.internal.lock().on_incomming_broadcast(now_ms, source, msg);
+        }
+        while let Some(msg) = self.sdk.pop_control() {
+            match msg {
+                SdkControl::Register(alias) => {
+                    self.internal.lock().register(now_ms, alias);
+                },
+                SdkControl::Unregister(alias) => {
+                    self.internal.lock().unregister(now_ms, &alias);
+                },
+                SdkControl::Query(alias, sender) => {
+                    self.internal.lock().find_alias(now_ms, &alias, sender);
+                }
+            }
+        }
+    }
+
+    fn on_sdk_msg(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _from_service: u8, _event: SE) {}
+
+    fn on_local_msg(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _msg: TransportMsg) {
+        panic!("Should not happend");
+    }
+
+    fn check_incoming_connection(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node: NodeId, _conn_id: ConnId) -> Result<(), ConnectionRejectReason> {
+        Ok(())
+    }
+
+    fn check_outgoing_connection(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node: NodeId, _conn_id: ConnId) -> Result<(), ConnectionRejectReason> {
+        Ok(())
+    }
+
+    fn on_incoming_connection_connected(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _conn: Arc<dyn ConnectionSender>) -> Option<Box<dyn ConnectionHandler<BE, HE>>> {
+        Some(Box::new(NodeAliasHandler { internal: self.internal.clone() }))
+    }
+
+    fn on_outgoing_connection_connected(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _conn: Arc<dyn ConnectionSender>) -> Option<Box<dyn ConnectionHandler<BE, HE>>> {
+        Some(Box::new(NodeAliasHandler { internal: self.internal.clone() }))
+    }
+
+    fn on_incoming_connection_disconnected(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node_id: NodeId, _conn_id: ConnId) {
+        
+    }
+
+    fn on_outgoing_connection_disconnected(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node_id: NodeId, _conn_id: ConnId) {
+        
+    }
+
+    fn on_outgoing_connection_error(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node_id: NodeId, _conn_id: ConnId, _err: &OutgoingConnectionError) {
+        
+    }
+
+    fn on_handler_event(&mut self, _ctx: &BehaviorContext, _now_ms: u64, _node_id: NodeId, _conn_id: ConnId, _event: BE) {}
+
+    fn on_stopped(&mut self, _ctx: &BehaviorContext, _now_ms: u64) {
+        if let Some(task) = self.pubsub_task.take() {
+            async_std::task::spawn(async move {
+                task.cancel().await;
+            });
+        }
+    }
+
+    fn pop_action(&mut self) -> Option<NetworkBehaviorAction<HE, SE>> {
+        match self.internal.lock().pop_action() {
+            Some(ServiceInternalAction::Broadcast(msg)) => {
+                log::info!("[NodeAliasBehavior {}] Broadcasting: {:?}", self.node_id, msg);
+                let msg = bincode::serialize(&msg).unwrap();
+                self.pub_channel.send(Bytes::from(msg));
+                None
+            },
+            Some(ServiceInternalAction::Unicast(dest, msg)) => {
+                log::info!("[NodeAliasBehavior {}] Unicasting to {}: {:?}", self.node_id, dest, msg);
+                let header = MsgHeader::build(NODE_ALIAS_SERVICE_ID, NODE_ALIAS_SERVICE_ID, RouteRule::ToNode(dest))
+                    .set_from_node(Some(self.node_id));
+                Some(NetworkBehaviorAction::ToNet(TransportMsg::from_payload_bincode(header, &msg)))
+            },
+            None => None,
+        }
+    }
+}

--- a/packages/services/node_alias/src/handler.rs
+++ b/packages/services/node_alias/src/handler.rs
@@ -7,7 +7,7 @@ use atm0s_sdn_network::{
 };
 use parking_lot::Mutex;
 
-use crate::{msg::DirectMsg, internal::ServiceInternal};
+use crate::{internal::ServiceInternal, msg::DirectMsg};
 
 pub struct NodeAliasHandler {
     pub(crate) internal: Arc<Mutex<ServiceInternal>>,

--- a/packages/services/node_alias/src/handler.rs
+++ b/packages/services/node_alias/src/handler.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use atm0s_sdn_identity::{ConnId, NodeId};
+use atm0s_sdn_network::{
+    behaviour::{ConnectionContext, ConnectionHandler, ConnectionHandlerAction},
+    transport::ConnectionEvent,
+};
+use parking_lot::Mutex;
+
+use crate::{msg::DirectMsg, internal::ServiceInternal};
+
+pub struct NodeAliasHandler {
+    pub(crate) internal: Arc<Mutex<ServiceInternal>>,
+}
+
+impl<BE, HE> ConnectionHandler<BE, HE> for NodeAliasHandler {
+    /// Called when the connection is opened.
+    fn on_opened(&mut self, _ctx: &ConnectionContext, _now_ms: u64) {}
+
+    /// Called on each tick of the connection.
+    fn on_tick(&mut self, _ctx: &ConnectionContext, _now_ms: u64, _interval_ms: u64) {}
+
+    /// Called when the connection is awake.
+    fn on_awake(&mut self, _ctx: &ConnectionContext, _now_ms: u64) {}
+
+    /// Called when an event occurs on the connection.
+    fn on_event(&mut self, _ctx: &ConnectionContext, now_ms: u64, event: ConnectionEvent) {
+        if let ConnectionEvent::Msg(msg) = event {
+            if let Some(from) = msg.header.from_node {
+                if let Ok(msg) = msg.get_payload_bincode::<DirectMsg>() {
+                    self.internal.lock().on_incomming_unicast(now_ms, from, msg);
+                }
+            }
+        }
+    }
+
+    /// Called when an event occurs on another handler.
+    fn on_other_handler_event(&mut self, _ctx: &ConnectionContext, _now_ms: u64, _from_node: NodeId, _from_conn: ConnId, _event: HE) {}
+
+    /// Called when an event occurs on the behavior.
+    fn on_behavior_event(&mut self, _ctx: &ConnectionContext, _now_ms: u64, _event: HE) {}
+
+    /// Called when the connection is closed.
+    fn on_closed(&mut self, _ctx: &ConnectionContext, _now_ms: u64) {}
+
+    /// Pops the next action to be taken by the connection handler.
+    fn pop_action(&mut self) -> Option<ConnectionHandlerAction<BE, HE>> {
+        None
+    }
+}

--- a/packages/services/node_alias/src/internal.rs
+++ b/packages/services/node_alias/src/internal.rs
@@ -1,0 +1,277 @@
+use std::collections::{HashMap, VecDeque, hash_map::Entry};
+
+use atm0s_sdn_identity::NodeId;
+
+use crate::{msg::{DirectMsg, BroadcastMsg}, sdk::{NodeAliasError, NodeAliasResult}, NodeAliasId};
+
+const FIND_ALIAS_TIMEOUT: u64 = 1000;
+const SCAN_ALIAS_TIMEOUT: u64 = 5000;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AliasHistory {
+    node: NodeId,
+    last_seen: u64,
+}
+
+impl PartialOrd for AliasHistory {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.node.partial_cmp(&other.node) {
+            Some(core::cmp::Ordering::Equal) => {}
+            ord => return ord,
+        }
+        self.last_seen.partial_cmp(&other.last_seen)
+    }
+}
+
+pub enum AliasFindingState {
+    Ping {
+        started_at: u64,
+        waits: Vec<Box<dyn FnOnce(Result<NodeAliasResult, NodeAliasError>) + Send>>,
+    },
+    Scan {
+        started_at: u64,
+        waits: Vec<Box<dyn FnOnce(Result<NodeAliasResult, NodeAliasError>) + Send>>,
+    }
+}
+
+pub struct AliasSlot {
+    /// When the alias was registered as local
+    local_at: Option<u64>,
+    /// Last time we saw this alias on the network
+    remote_hint: Option<AliasHistory>,
+}
+
+pub enum ServiceInternalAction {
+    Unicast(NodeId, DirectMsg),
+    Broadcast(BroadcastMsg),
+}
+
+pub struct ServiceInternal {
+    node_id: NodeId,
+    aliases: HashMap<NodeAliasId, AliasSlot>,
+    finding_aliases: HashMap<NodeAliasId, AliasFindingState>,
+    action: VecDeque<ServiceInternalAction>,
+}
+
+impl ServiceInternal {
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            aliases: HashMap::new(),
+            finding_aliases: HashMap::new(),
+            action: VecDeque::new(),
+        }
+    }
+
+    /// adding the alias as local
+    pub fn register(&mut self, now_ms: u64, alias: NodeAliasId) {
+        match self.aliases.entry(alias.clone()) {
+            Entry::Occupied(mut entry) => {
+                log::info!("[ServiceInternal {}] Registering a local alias {} that was already registered as remote", self.node_id, entry.key());
+                entry.get_mut().local_at = Some(now_ms);
+            }
+            Entry::Vacant(entry) => {
+                log::info!("[ServiceInternal {}] Registering a new alias {} as local", self.node_id, entry.key());
+                entry.insert(AliasSlot {
+                    local_at: Some(now_ms),
+                    remote_hint: None
+                });
+            }
+        }
+        self.action.push_back(ServiceInternalAction::Broadcast(BroadcastMsg::Register(alias)));
+    }
+
+    pub fn unregister(&mut self, _now_ms: u64, alias: &NodeAliasId) {
+        if let Some(slot) = self.aliases.get_mut(&alias) {
+            if slot.local_at.is_some() {
+                slot.local_at = None;
+                if slot.remote_hint.is_none() {
+                    log::info!("[ServiceInternal {}] Unregistering a local alias {} => removed", self.node_id, alias);
+                    self.aliases.remove(&alias);
+                } else {
+                    log::info!("[ServiceInternal {}] Unregistering a local alias {} that was registered as remote", self.node_id, alias);
+                }
+                self.action.push_back(ServiceInternalAction::Broadcast(BroadcastMsg::Unregister(alias.clone())));
+            } else {
+                panic!("Cannot unregister a remote alias");
+            }
+        } else {
+            panic!("Cannot unregister an unknown alias");
+        }
+    }
+
+    pub fn on_tick(&mut self, now_ms: u64) {
+        // check if alias finding timeout
+        let mut to_remove = Vec::new();
+        for (alias, finding) in self.finding_aliases.iter_mut() {
+            match finding {
+                AliasFindingState::Ping { started_at, waits } => {
+                    if now_ms >= *started_at + FIND_ALIAS_TIMEOUT {
+                        log::info!("[ServiceInternal {}] Alias {} finding timeout => trying SCAN", self.node_id, alias);
+                        *finding = AliasFindingState::Scan {
+                            started_at: now_ms,
+                            waits: waits.drain(..).collect(),
+                        };
+                        self.action.push_back(ServiceInternalAction::Broadcast(BroadcastMsg::Query(alias.clone())));
+                    }
+                },
+                AliasFindingState::Scan { started_at, waits } => {
+                    if now_ms >= *started_at + SCAN_ALIAS_TIMEOUT {
+                        log::info!("[ServiceInternal {}] Alias {} scan timeout => not found", self.node_id, alias);
+                        to_remove.push(alias.clone());
+                        waits.drain(..).for_each(|wait| wait(Err(NodeAliasError::Timeout)));
+                    }
+                }
+            }
+        }
+        to_remove.drain(..).for_each(|alias| {
+            self.finding_aliases.remove(&alias);
+        });
+    }
+
+    /// First find in local if not found then PING hint node, if not found SCAN by broadcast
+    pub fn find_alias(&mut self, now_ms: u64, alias: &NodeAliasId, handler: Box<dyn FnOnce(Result<NodeAliasResult, NodeAliasError>) + Send>) {
+        log::info!("[ServiceInternal {}] Find alias {}", self.node_id, alias);
+        let (local, remote) = match self.aliases.get(alias) {
+            Some(slot) => (slot.local_at.is_some(), slot.remote_hint.as_ref().map(|hint| hint.node)),
+            None => (false, None),
+        };
+
+        if local {
+            log::info!("[ServiceInternal {}] Alias {} found locally", self.node_id, alias);
+            handler(Ok(NodeAliasResult::FromLocal));
+        } else {
+            if let Some(finding) = self.finding_aliases.get_mut(alias) {
+                log::info!("[ServiceInternal {}] Alias {} already finding => push to wait queue", self.node_id, alias);
+                match finding {
+                    AliasFindingState::Ping { waits, .. } => {
+                        waits.push(handler);
+                    },
+                    AliasFindingState::Scan { waits, .. } => {
+                        waits.push(handler);
+                    }
+                }
+            } else {
+                if let Some(remote_hint_node) = remote {
+                    log::info!("[ServiceInternal {}] Alias {} hint node found => trying PING node {}", self.node_id, alias, remote_hint_node);
+                    self.finding_aliases.insert(alias.clone(), AliasFindingState::Ping {
+                        started_at: now_ms,
+                        waits: vec![handler],
+                    });
+                    self.action.push_back(ServiceInternalAction::Unicast(remote_hint_node, DirectMsg::Query(alias.clone())));
+                } else {
+                    log::info!("[ServiceInternal {}] Alias {} hint node not found => trying SCAN", self.node_id, alias);
+                    self.finding_aliases.insert(alias.clone(), AliasFindingState::Scan {
+                        started_at: now_ms,
+                        waits: vec![handler],
+                    });
+                    self.action.push_back(ServiceInternalAction::Broadcast(BroadcastMsg::Query(alias.clone())));
+                }
+            }
+        }
+    }
+
+    pub fn on_incomming_unicast(&mut self, _now_ms: u64, from: NodeId, msg: DirectMsg) {
+        match msg {
+            DirectMsg::Response { alias, added_at } => {
+                // When we receive a response we update the alias hint if the response is found.
+                // We also check if current finding state is PING or SCAN and if so we call the handler if required
+
+                if let Some(added_at) = added_at {
+                    log::info!("[ServiceInternal {}] update alias {} hint to {}", self.node_id, alias, from);
+                    self.aliases.entry(alias.clone()).or_insert(AliasSlot {
+                        local_at: None,
+                        remote_hint: None,
+                    }).remote_hint = Some(AliasHistory {
+                        node: from,
+                        last_seen: added_at,
+                    });
+                }
+
+                if let Some(finding) = self.finding_aliases.get_mut(&alias) {
+                    match finding {
+                        AliasFindingState::Ping { started_at, waits } => {
+                            if added_at.is_some() {
+                                log::info!("[ServiceInternal {}] Alias {} found by PING at {}", self.node_id, alias, from);
+                                waits.drain(..).for_each(|wait| wait(Ok(NodeAliasResult::FromHint(from))));
+                                self.finding_aliases.remove(&alias);
+                            } else  {
+                                *finding = AliasFindingState::Scan {
+                                    started_at: *started_at,
+                                    waits: waits.drain(..).collect(),
+                                };
+                                self.action.push_back(ServiceInternalAction::Broadcast(BroadcastMsg::Query(alias)));
+                            }
+                        },
+                        AliasFindingState::Scan { started_at: _, waits } => {
+                            if added_at.is_some() {
+                                log::info!("[ServiceInternal {}] Alias {} found by SCAN at {}", self.node_id, alias, from);
+                                waits.drain(..).for_each(|wait| wait(Ok(NodeAliasResult::FromScan(from))));
+                                self.finding_aliases.remove(&alias);
+                            }
+                        }
+                    }
+                }
+            },
+            DirectMsg::Query(alias) => {
+                let added_at = self.aliases.get(&alias).and_then(|slot| slot.local_at);
+                self.action.push_back(ServiceInternalAction::Unicast(from, DirectMsg::Response {
+                    alias,
+                    added_at,
+                }));
+            }
+        }
+    }
+
+    pub fn on_incomming_broadcast(&mut self, now_ms: u64, from: NodeId, msg: BroadcastMsg) {
+        match msg {
+            BroadcastMsg::Register(alias) => {
+                // save the alias as remote
+                match self.aliases.entry(alias) {
+                    Entry::Occupied(mut entry) => {
+                        log::info!("[ServiceInternal {}] Registering a remote alias {} that was already registered", self.node_id, entry.key());
+                        entry.get_mut().remote_hint = Some(AliasHistory {
+                            node: from,
+                            last_seen: now_ms,
+                        });
+                    }
+                    Entry::Vacant(entry) => {
+                        log::info!("[ServiceInternal {}] Registering a new alias {} as remote", self.node_id, entry.key());
+                        entry.insert(AliasSlot {
+                            local_at: None,
+                            remote_hint: Some(AliasHistory {
+                                node: from,
+                                last_seen: now_ms,
+                            })
+                        });
+                    }
+                }
+            },
+            BroadcastMsg::Unregister(alias) => {
+                // clear alias hint if from same node
+                if let Some(slot) = self.aliases.get_mut(&alias) {
+                    if slot.remote_hint.as_ref().map(|hint| hint.node == from).unwrap_or(false) {
+                        log::info!("[ServiceInternal {}] Unregistering a remote alias {} => removed hint", self.node_id, alias);
+                        slot.remote_hint = None;
+                    } else {
+                        log::info!("[ServiceInternal {}] Ignore unregistering a remote alias {} but from node difference with last hint", self.node_id, alias);
+                    }
+                } else {
+                    log::warn!("[ServiceInternal {}] Unregistering an unknown alias {}", self.node_id, alias);
+                }
+            },
+            BroadcastMsg::Query(alias) => {
+                let added_at = self.aliases.get(&alias).and_then(|slot| slot.local_at);
+                log::info!("[ServiceInternal {}] On Alias ({}) Query, local {}", self.node_id, alias, added_at.is_some());
+                self.action.push_back(ServiceInternalAction::Unicast(from, DirectMsg::Response {
+                    alias,
+                    added_at,
+                }));
+            }
+        }
+    }
+
+    pub fn pop_action(&mut self) -> Option<ServiceInternalAction> {
+        self.action.pop_front()
+    }
+}

--- a/packages/services/node_alias/src/lib.rs
+++ b/packages/services/node_alias/src/lib.rs
@@ -1,20 +1,20 @@
 use std::{fmt::Display, ops::Deref};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 mod behavior;
 mod handler;
-mod sdk;
-mod msg;
 mod internal;
+mod msg;
+mod sdk;
 
 pub(crate) const NODE_ALIAS_SERVICE_ID: u8 = 7;
 
-pub use sdk::{NodeAliasSdk, NodeAliasResult, NodeAliasError};
 pub use behavior::NodeAliasBehavior;
+pub use sdk::{NodeAliasError, NodeAliasResult, NodeAliasSdk};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct NodeAliasId (u64);
+pub struct NodeAliasId(u64);
 
 impl Display for NodeAliasId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -30,7 +30,7 @@ impl From<u64> for NodeAliasId {
 
 impl Deref for NodeAliasId {
     type Target = u64;
-    
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/packages/services/node_alias/src/lib.rs
+++ b/packages/services/node_alias/src/lib.rs
@@ -35,3 +35,24 @@ impl Deref for NodeAliasId {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(test)]
+    mod tests {
+        use crate::NodeAliasId;
+
+        #[test]
+        fn test_node_alias_id_display() {
+            let alias_id = NodeAliasId(123);
+            assert_eq!(format!("{}", alias_id), "Alias(123)");
+        }
+
+        #[test]
+        fn test_node_alias_id_from() {
+            let value: u64 = 456;
+            let alias_id: NodeAliasId = value.into();
+            assert_eq!(*alias_id, value);
+        }
+    }
+}

--- a/packages/services/node_alias/src/lib.rs
+++ b/packages/services/node_alias/src/lib.rs
@@ -1,0 +1,37 @@
+use std::{fmt::Display, ops::Deref};
+
+use serde::{Serialize, Deserialize};
+
+mod behavior;
+mod handler;
+mod sdk;
+mod msg;
+mod internal;
+
+pub(crate) const NODE_ALIAS_SERVICE_ID: u8 = 7;
+
+pub use sdk::{NodeAliasSdk, NodeAliasResult, NodeAliasError};
+pub use behavior::NodeAliasBehavior;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NodeAliasId (u64);
+
+impl Display for NodeAliasId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Alias({})", self.0)
+    }
+}
+
+impl From<u64> for NodeAliasId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for NodeAliasId {
+    type Target = u64;
+    
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/packages/services/node_alias/src/msg.rs
+++ b/packages/services/node_alias/src/msg.rs
@@ -1,17 +1,17 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use crate::{NodeAliasId, sdk::{NodeAliasError, NodeAliasResult}};
+use crate::{
+    sdk::{NodeAliasError, NodeAliasResult},
+    NodeAliasId,
+};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub(crate) enum DirectMsg {
     Query(NodeAliasId),
-    Response {
-        alias: NodeAliasId,
-        added_at: Option<u64>,
-    },
+    Response { alias: NodeAliasId, added_at: Option<u64> },
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub(crate) enum BroadcastMsg {
     Register(NodeAliasId),
     Unregister(NodeAliasId),

--- a/packages/services/node_alias/src/msg.rs
+++ b/packages/services/node_alias/src/msg.rs
@@ -1,0 +1,25 @@
+use serde::{Serialize, Deserialize};
+
+use crate::{NodeAliasId, sdk::{NodeAliasError, NodeAliasResult}};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum DirectMsg {
+    Query(NodeAliasId),
+    Response {
+        alias: NodeAliasId,
+        added_at: Option<u64>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum BroadcastMsg {
+    Register(NodeAliasId),
+    Unregister(NodeAliasId),
+    Query(NodeAliasId),
+}
+
+pub(crate) enum SdkControl {
+    Register(NodeAliasId),
+    Unregister(NodeAliasId),
+    Query(NodeAliasId, Box<dyn FnOnce(Result<NodeAliasResult, NodeAliasError>) + Send>),
+}

--- a/packages/services/node_alias/src/sdk.rs
+++ b/packages/services/node_alias/src/sdk.rs
@@ -1,0 +1,59 @@
+use std::{sync::Arc, collections::VecDeque};
+
+use atm0s_sdn_identity::NodeId;
+use atm0s_sdn_utils::awaker::Awaker;
+use parking_lot::Mutex;
+
+use crate::{msg::SdkControl, NodeAliasId};
+
+#[derive(Debug, PartialEq)]
+pub enum NodeAliasResult {
+    FromLocal,
+    FromHint(NodeId),
+    FromScan(NodeId),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum NodeAliasError {
+    Timeout,
+}
+
+#[derive(Clone, Default)]
+pub struct NodeAliasSdk {
+    sdk_control_queue: Arc<Mutex<VecDeque<SdkControl>>>,
+    awaker: Arc<Mutex<Option<Arc<dyn Awaker>>>>,
+}
+
+impl NodeAliasSdk {
+    pub(crate) fn set_awaker(&self, awaker: Arc<dyn Awaker>) {
+        *self.awaker.lock() = Some(awaker);
+    }
+    
+    pub fn register(&self, alias: NodeAliasId) {
+        log::info!("[NodeAliasSdk] Register alias: {}", alias);
+        self.sdk_control_queue.lock().push_back(SdkControl::Register(alias));
+        if let Some(awaker) = &*self.awaker.lock() {
+            awaker.notify();
+        }
+    }
+
+    pub fn unregister(&self, alias: NodeAliasId) {
+        log::info!("[NodeAliasSdk] Unregister alias: {}", alias);
+        self.sdk_control_queue.lock().push_back(SdkControl::Unregister(alias));
+        if let Some(awaker) = &*self.awaker.lock() {
+            awaker.notify();
+        }
+    }
+
+    pub fn find_alias(&self, alias: NodeAliasId, handler: Box<dyn FnOnce(Result<NodeAliasResult, NodeAliasError>) + Send>) {
+        log::info!("[NodeAliasSdk] Find alias: {}", alias);
+        self.sdk_control_queue.lock().push_back(SdkControl::Query(alias, handler));
+        if let Some(awaker) = &*self.awaker.lock() {
+            awaker.notify();
+        }
+    }
+
+    pub(crate) fn pop_control(&self) -> Option<SdkControl> {
+        self.sdk_control_queue.lock().pop_front()
+    }
+}

--- a/packages/services/node_alias/src/sdk.rs
+++ b/packages/services/node_alias/src/sdk.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, collections::VecDeque};
+use std::{collections::VecDeque, sync::Arc};
 
 use atm0s_sdn_identity::NodeId;
 use atm0s_sdn_utils::awaker::Awaker;
@@ -28,7 +28,7 @@ impl NodeAliasSdk {
     pub(crate) fn set_awaker(&self, awaker: Arc<dyn Awaker>) {
         *self.awaker.lock() = Some(awaker);
     }
-    
+
     pub fn register(&self, alias: NodeAliasId) {
         log::info!("[NodeAliasSdk] Register alias: {}", alias);
         self.sdk_control_queue.lock().push_back(SdkControl::Register(alias));


### PR DESCRIPTION
# atm0s-sdn Node Alias Service

This service implements a DNS-style mechanism where each node registers itself along with a number of aliases. These aliases are typically used on proxy or tunnel servers.

## Functionality

The mechanism used here helps avoid the need for strong synchronization data between nodes. Any node can disconnect and rejoin at any time. The process is quite straightforward, as explained below:

- Every time a node registers or unregisters an alias, it broadcasts this change to all other nodes.
- When a node receives a registration, it stores the sender as the location hint.
- When a node needs to find a location for an alias, it first checks its local storage for the location hint.

    - It pings the location hint to ensure it still holds the alias.
    - If there's no location hint, or if the ping times out or the node replies with 'NOT FOUND', the node broadcasts a 'SCAN' request to all other nodes.
    - If a node replies with 'FOUND', then the result is obtained. However, if after a timeout there's no 'FOUND' response, it means the alias was not found.

## Usecase

This mechanism proves particularly useful when dealing with a large number of aliases that rarely change. This can be observed in systems like DNS, Tunnels, and Proxies. However, this service should not be used if you have aliases that frequently change and are queried often.