### PR TITLE
fix: key value service resub before subscribe slot removed was failed

### DIFF
--- a/packages/services/key_value/src/storage/hashmap.rs
+++ b/packages/services/key_value/src/storage/hashmap.rs
@@ -183,11 +183,13 @@ where
         slot.value
     }
 
-    pub fn subscribe(&mut self, now_ms: u64, key: &Key, handler_uuid: Handler, ex: Option<u64>) {
+    /// return true if subscribe success, false if already subscribed
+    pub fn subscribe(&mut self, now_ms: u64, key: &Key, handler_uuid: Handler, ex: Option<u64>) -> bool {
         match self.maps.get_mut(key) {
             Some(slot) => match slot.listeners.entry(handler_uuid.clone()) {
                 hash_map::Entry::Occupied(mut entry) => {
                     entry.get_mut().expire_at = ex.map(|ex| now_ms + ex);
+                    false
                 }
                 hash_map::Entry::Vacant(entry) => {
                     entry.insert(HandlerSlot {
@@ -200,6 +202,7 @@ where
                                 .push_back(OutputEvent::NotifySet(key.clone(), sub_key.clone(), value.clone(), *version, source.clone(), handler_uuid.clone()));
                         }
                     }
+                    true
                 }
             },
             None => {
@@ -216,6 +219,7 @@ where
                         )]),
                     },
                 );
+                true
             }
         }
     }

--- a/packages/services/key_value/src/storage/simple.rs
+++ b/packages/services/key_value/src/storage/simple.rs
@@ -156,11 +156,13 @@ where
         }
     }
 
-    pub fn subscribe(&mut self, now_ms: u64, key: &Key, handler_uuid: Handler, ex: Option<u64>) {
+    /// return true if subscribe success, false if already subscribed
+    pub fn subscribe(&mut self, now_ms: u64, key: &Key, handler_uuid: Handler, ex: Option<u64>) -> bool {
         match self.keys.get_mut(key) {
             Some(slot) => match slot.listeners.entry(handler_uuid.clone()) {
                 hash_map::Entry::Occupied(mut sub_slot) => {
                     sub_slot.get_mut().expire_at = ex.map(|ex| now_ms + ex);
+                    false
                 }
                 hash_map::Entry::Vacant(sub_slot) => {
                     sub_slot.insert(HandlerSlot {
@@ -170,6 +172,7 @@ where
                     if let Some((value, version, source)) = &slot.value {
                         self.events.push_back(OutputEvent::NotifySet(key.clone(), value.clone(), *version, source.clone(), handler_uuid));
                     }
+                    true
                 }
             },
             None => {
@@ -187,6 +190,7 @@ where
                         )]),
                     },
                 );
+                true
             }
         }
     }

--- a/packages/services/pub_sub/src/relay.rs
+++ b/packages/services/pub_sub/src/relay.rs
@@ -103,7 +103,7 @@ impl PubsubRelay {
 
     pub fn on_source_added(&self, channel: ChannelUuid, source: NodeId) {
         if let Some(subs) = self.source_binding.write().on_source_added(channel, source) {
-            log::debug!("[PubsubRelay] channel {} added source  {} => auto sub for local subs {:?}", channel, source, subs);
+            log::info!("[PubsubRelay] channel {} added source  {} => auto sub for local subs {:?}", channel, source, subs);
             for sub in subs {
                 self.logic.write().on_local_sub(ChannelIdentify::new(channel, source), sub);
             }
@@ -112,7 +112,7 @@ impl PubsubRelay {
 
     pub fn on_source_removed(&self, channel: ChannelUuid, source: NodeId) {
         if let Some(subs) = self.source_binding.write().on_source_removed(channel, source) {
-            log::debug!("[PubsubRelay] channel {} removed source {} => auto unsub for local subs {:?}", channel, source, subs);
+            log::info!("[PubsubRelay] channel {} removed source {} => auto unsub for local subs {:?}", channel, source, subs);
             for sub in subs {
                 self.logic.write().on_local_unsub(ChannelIdentify::new(channel, source), sub);
             }


### PR DESCRIPTION
This PR fixes the key-value service in the following cases:

- SUBscribing to a key
- UNSUBscribing from the key
- re-SUBscribing to the key before the subscribe slot is removed (after UNSUB_ACK after a few seconds)

The result is that the SUB message will not be sent. This bug occurs with both single key values and hash-map key-values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized internal operations to ensure efficiency and reduced unnecessary processing.
- **New Features**
	- Enhanced logging for key operations, improving visibility for system monitoring.
	- Subscription functionality now indicates success more clearly, aiding in better management of subscriptions.
- **Tests**
	- Added comprehensive tests for subscription and unsubscription functionalities to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->