### PR TITLE
feat: meta in virtual socket for implement enc, quic-tunnel example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ log = "0.4"
 rand = "0.8"
 parking_lot = "0.12"
 env_logger = "0.11"
-clap = { version = "4.4.18", features = ["derive", "env"] }
+clap = { version = "4.4", features = ["derive", "env"] }
 mockall = "0.12.1"

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+target
+Cargo.lock
+.idea
+.vscode

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = [
+    "quic-tunnel"
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace.dependencies]
+atm0s-sdn = { path = "../packages/runner" }
+tracing-subscriber = "0.3"
+signal-hook = "0.3"
+clap = { version = "4.4", features = ["derive", "env"] }
+tokio = { version = "1", features = ["full"] }
+log = "0.4"

--- a/examples/quic-tunnel/Cargo.toml
+++ b/examples/quic-tunnel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "quic-tunnel"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log.workspace = true
+tracing-subscriber.workspace = true
+clap.workspace = true
+tokio.workspace = true
+atm0s-sdn.workspace = true
+signal-hook.workspace = true
+quinn = { version = "0.10", default-features = false, features = ["runtime-tokio", "log", "ring"] }
+quinn-plaintext = "0.2.0"

--- a/examples/quic-tunnel/README.md
+++ b/examples/quic-tunnel/README.md
@@ -1,0 +1,3 @@
+# Quic-tunnel
+
+This sample implement a simple tunnel using QUIC protocol. It is based on the virtual socket feature and Quinn crate.

--- a/examples/quic-tunnel/src/main.rs
+++ b/examples/quic-tunnel/src/main.rs
@@ -1,0 +1,181 @@
+use std::{
+    net::{SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
+
+use atm0s_sdn::{NodeAddr, NodeId};
+use clap::Parser;
+use quinn::{AsyncUdpSocket, Connecting, ConnectionError, Endpoint, EndpointConfig, TokioRuntime};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    select,
+};
+use vnet::VirtualUdpSocket;
+
+mod sdn;
+mod vnet;
+
+/// Quic-tunnel demo application
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Node Id
+    #[arg(env, short, long, default_value_t = 0)]
+    node_id: NodeId,
+
+    /// Listen address
+    #[arg(env, short, long, default_value_t = 0)]
+    udp_port: u16,
+
+    /// Address of node we should connect to
+    #[arg(env, short, long)]
+    seeds: Vec<NodeAddr>,
+
+    /// Password for the network
+    #[arg(env, short, long, default_value = "password")]
+    password: String,
+
+    /// Workers
+    #[arg(env, long, default_value_t = 2)]
+    workers: usize,
+
+    /// Bind addr
+    #[arg(env, short, long, default_value = "0.0.0.0:8000")]
+    bind_addr: SocketAddr,
+
+    /// Tunnel to node
+    #[arg(env, short, long)]
+    dest_node: Option<NodeId>,
+
+    /// Tunnel to local
+    #[arg(env, short, long)]
+    local_tunnel: Option<SocketAddr>,
+}
+
+#[tokio::main]
+async fn main() {
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "info");
+    }
+    let args = Args::parse();
+    tracing_subscriber::fmt::init();
+
+    let (mut vnet, tx, rx) = vnet::VirtualNetwork::new(args.node_id);
+
+    if let Some(dest_tunnel) = args.local_tunnel {
+        let socket = vnet.udp_socket(10000).await;
+        let runtime = Arc::new(TokioRuntime);
+        let mut config = EndpointConfig::default();
+        config.max_udp_payload_size(1500).expect("Should config quinn server max_size to 1500");
+        let endpoint = Endpoint::new_with_abstract_socket(config, Some(quinn_plaintext::server_config()), socket, runtime).expect("Should create quinn endpoint");
+
+        tokio::spawn(async move {
+            while let Some(connecting) = endpoint.accept().await {
+                log::info!("Got quic connecting event from {}", connecting.remote_address());
+                tokio::spawn(async move {
+                    if let Err(e) = tunnel_incoming_quic(connecting, dest_tunnel).await {
+                        log::error!("Tunnel error {:?}", e);
+                    }
+                });
+            }
+        });
+
+        tokio::spawn(async move {
+            log::info!("QUIN Server started");
+            while let Some(_) = vnet.recv().await {}
+            log::info!("QUIN Server stopped");
+        });
+    } else if let Some(dest_node) = args.dest_node {
+        let addr = args.bind_addr;
+        let tcp_server = TcpListener::bind(addr).await.expect("Should bind to addr");
+        tokio::spawn(async move {
+            log::info!("TCP Server started at {addr}");
+            loop {
+                select! {
+                    e = tcp_server.accept() => match e {
+                        Ok((stream, addr)) => {
+                            log::info!("Accept tcp connection from {addr}");
+                            let socket = vnet.udp_socket(0).await;
+                            log::info!("Create virtual udp socket at {}", socket.local_addr().expect("should have local_addr"));
+                            tokio::spawn(async move {
+                                if let Err(e) = tunnel_outgoing_quic(socket, stream, addr, dest_node).await {
+                                    log::error!("Tunnel error {:?}", e);
+                                }
+                            });
+                        },
+                        Err(err) => {
+                            log::error!("Accept error {:?}", err);
+                            break;
+                        }
+                    },
+                    e = vnet.recv() => match e {
+                        Some(_) => {},
+                        None => break,
+                    }
+                }
+            }
+            log::info!("TCP Server stopped");
+        });
+    }
+
+    sdn::run_sdn(args.node_id, args.udp_port, args.seeds, args.workers, tx, rx).await;
+    log::info!("Server shutdown");
+}
+
+#[derive(Debug)]
+enum Error {
+    Quic(ConnectionError),
+    Tcp(std::io::Error),
+}
+
+async fn tunnel_incoming_quic(connecting: Connecting, dest_tunnel: SocketAddr) -> Result<(), Error> {
+    let conn = connecting.await.map_err(Error::Quic)?;
+    log::info!("Accepted quic connection from {}", conn.remote_address());
+    let (mut send, mut recv) = conn.accept_bi().await.map_err(Error::Quic)?;
+    log::info!("Accepted quic bi stream from {}", conn.remote_address());
+    let target_stream = TcpStream::connect(dest_tunnel).await.map_err(Error::Tcp)?;
+    let (mut target_recv, mut target_send) = target_stream.into_split();
+
+    tokio::spawn(async move {
+        if let Err(e) = tokio::io::copy(&mut recv, &mut target_send).await {
+            log::info!("Copy error {:?}", e);
+        }
+    });
+
+    if let Err(e) = tokio::io::copy(&mut target_recv, &mut send).await {
+        log::info!("Copy error {:?}", e);
+    }
+
+    log::info!("Quic connection from {} closed", conn.remote_address());
+    Ok(())
+}
+
+async fn tunnel_outgoing_quic(socket: VirtualUdpSocket, stream: TcpStream, remote: SocketAddr, dest_node: NodeId) -> Result<(), Error> {
+    let mut config = EndpointConfig::default();
+    //Note that client mtu size shoud be smaller than server's
+    config.max_udp_payload_size(1400).expect("Should config quinn client max_size to 1400");
+    let mut endpoint = Endpoint::new_with_abstract_socket(config, None, socket, Arc::new(TokioRuntime)).expect("Should create endpoint");
+    endpoint.set_default_client_config(quinn_plaintext::client_config());
+
+    log::info!("Connecting to node {}", dest_node);
+    let connecting = endpoint
+        .connect(SocketAddr::V4(SocketAddrV4::new(dest_node.into(), 10000)), "tunnel")
+        .expect("Should connect to server");
+    let conn = connecting.await.map_err(Error::Quic)?;
+    log::info!("Connected to node {} with quic", dest_node);
+    let (mut send, mut recv) = conn.open_bi().await.map_err(Error::Quic)?;
+    log::info!("Open quic bi stream to node {}", dest_node);
+    let (mut target_recv, mut target_send) = stream.into_split();
+
+    tokio::spawn(async move {
+        if let Err(e) = tokio::io::copy(&mut recv, &mut target_send).await {
+            log::info!("Copy error {:?}", e);
+        }
+    });
+
+    if let Err(e) = tokio::io::copy(&mut target_recv, &mut send).await {
+        log::info!("Copy error {:?}", e);
+    }
+    log::info!("TCP connection from {remote} closed");
+    Ok(())
+}

--- a/examples/quic-tunnel/src/sdn.rs
+++ b/examples/quic-tunnel/src/sdn.rs
@@ -1,0 +1,84 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use atm0s_sdn::{
+    builder::SdnBuilder,
+    features::{socket, FeaturesControl, FeaturesEvent},
+    sans_io_runtime::{backend::PollBackend, Owner},
+    services::visualization,
+    tasks::{SdnExtIn, SdnExtOut},
+    NodeAddr, NodeId,
+};
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::vnet::{NetworkPkt, OutEvent};
+
+type SC = visualization::Control;
+type SE = visualization::Event;
+type TC = ();
+type TW = ();
+
+pub async fn run_sdn(node_id: NodeId, udp_port: u16, seeds: Vec<NodeAddr>, workers: usize, tx: Sender<NetworkPkt>, mut rx: Receiver<OutEvent>) {
+    let term = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&term)).expect("Should register hook");
+    let mut shutdown_wait = 0;
+    let mut builder = SdnBuilder::<SC, SE, TC, TW>::new(node_id, udp_port, vec![]);
+
+    builder.set_manual_discovery(vec!["tunnel".to_string()], vec!["tunnel".to_string()]);
+    builder.set_visualization_collector(false);
+
+    for seed in seeds {
+        builder.add_seed(seed);
+    }
+
+    let mut controller = builder.build::<PollBackend<128, 128>>(workers);
+    while controller.process().is_some() {
+        if term.load(Ordering::Relaxed) {
+            if shutdown_wait == 200 {
+                log::warn!("Force shutdown");
+                break;
+            }
+            shutdown_wait += 1;
+            controller.shutdown();
+        }
+        while let Ok(c) = rx.try_recv() {
+            // log::info!("Command: {:?}", c);
+            match c {
+                OutEvent::Bind(port) => {
+                    controller.send_to(Owner::worker(0), SdnExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(port))));
+                }
+                OutEvent::Pkt(pkt) => {
+                    //TODO process ecn
+                    let send = socket::Control::SendTo(pkt.local_port, pkt.remote, pkt.remote_port, pkt.data);
+                    controller.send_to(Owner::worker(0), SdnExtIn::FeaturesControl(FeaturesControl::Socket(send)));
+                }
+                OutEvent::Unbind(port) => {
+                    controller.send_to(Owner::worker(0), SdnExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Unbind(port))));
+                }
+            }
+        }
+        while let Some(event) = controller.pop_event() {
+            // log::info!("Event: {:?}", event);
+            match event {
+                SdnExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(local_port, remote, remote_port, data))) => {
+                    if let Err(e) = tx.try_send(NetworkPkt {
+                        local_port,
+                        remote,
+                        remote_port,
+                        data,
+                        meta: 0, //TODO process ecn
+                    }) {
+                        log::error!("Failed to send to tx: {:?}", e);
+                    }
+                }
+                _ => {}
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}

--- a/examples/quic-tunnel/src/sdn.rs
+++ b/examples/quic-tunnel/src/sdn.rs
@@ -53,8 +53,7 @@ pub async fn run_sdn(node_id: NodeId, udp_port: u16, seeds: Vec<NodeAddr>, worke
                     controller.send_to(Owner::worker(0), SdnExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(port))));
                 }
                 OutEvent::Pkt(pkt) => {
-                    //TODO process ecn
-                    let send = socket::Control::SendTo(pkt.local_port, pkt.remote, pkt.remote_port, pkt.data);
+                    let send = socket::Control::SendTo(pkt.local_port, pkt.remote, pkt.remote_port, pkt.data, pkt.meta);
                     controller.send_to(Owner::worker(0), SdnExtIn::FeaturesControl(FeaturesControl::Socket(send)));
                 }
                 OutEvent::Unbind(port) => {
@@ -65,13 +64,13 @@ pub async fn run_sdn(node_id: NodeId, udp_port: u16, seeds: Vec<NodeAddr>, worke
         while let Some(event) = controller.pop_event() {
             // log::info!("Event: {:?}", event);
             match event {
-                SdnExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(local_port, remote, remote_port, data))) => {
+                SdnExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(local_port, remote, remote_port, data, meta))) => {
                     if let Err(e) = tx.try_send(NetworkPkt {
                         local_port,
                         remote,
                         remote_port,
                         data,
-                        meta: 0, //TODO process ecn
+                        meta,
                     }) {
                         log::error!("Failed to send to tx: {:?}", e);
                     }

--- a/examples/quic-tunnel/src/vnet/mod.rs
+++ b/examples/quic-tunnel/src/vnet/mod.rs
@@ -1,0 +1,95 @@
+use std::collections::{HashMap, VecDeque};
+
+use atm0s_sdn::NodeId;
+use tokio::{
+    select,
+    sync::mpsc::{channel, Receiver, Sender, UnboundedReceiver, UnboundedSender},
+};
+
+pub use self::socket::VirtualUdpSocket;
+
+mod socket;
+
+#[derive(Debug)]
+pub enum OutEvent {
+    Bind(u16),
+    Pkt(NetworkPkt),
+    Unbind(u16),
+}
+
+#[derive(Debug)]
+pub struct NetworkPkt {
+    pub local_port: u16,
+    pub remote: NodeId,
+    pub remote_port: u16,
+    pub data: Vec<u8>,
+    pub meta: u8,
+}
+
+pub struct VirtualNetwork {
+    node_id: NodeId,
+    in_rx: Receiver<NetworkPkt>,
+    out_tx: Sender<OutEvent>,
+    close_socket_tx: UnboundedSender<u16>,
+    close_socket_rx: UnboundedReceiver<u16>,
+    sockets: HashMap<u16, Sender<NetworkPkt>>,
+    ports: VecDeque<u16>,
+}
+
+impl VirtualNetwork {
+    pub fn new(node_id: NodeId) -> (Self, Sender<NetworkPkt>, Receiver<OutEvent>) {
+        let (in_tx, in_rx) = tokio::sync::mpsc::channel(1000);
+        let (out_tx, out_rx) = tokio::sync::mpsc::channel(1000);
+        let (close_socket_tx, close_socket_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        (
+            Self {
+                node_id,
+                in_rx,
+                out_tx,
+                close_socket_rx,
+                close_socket_tx,
+                sockets: HashMap::new(),
+                ports: (0..60000).collect(),
+            },
+            in_tx,
+            out_rx,
+        )
+    }
+
+    pub async fn udp_socket(&mut self, port: u16) -> VirtualUdpSocket {
+        //remove port from ports
+        let port = if port > 0 {
+            let index = self.ports.iter().position(|&x| x == port).expect("Should have port");
+            self.ports.swap_remove_back(index);
+            port
+        } else {
+            self.ports.pop_front().expect("Should have port")
+        };
+        self.out_tx.send(OutEvent::Bind(port)).await.expect("Should send bind");
+        let (tx, rx) = channel(1000);
+        self.sockets.insert(port, tx);
+        VirtualUdpSocket::new(self.node_id, port, self.out_tx.clone(), rx, self.close_socket_tx.clone())
+    }
+
+    pub async fn recv(&mut self) -> Option<()> {
+        select! {
+            port = self.close_socket_rx.recv() => {
+                let port = port.expect("Should have port");
+                self.ports.push_back(port);
+                self.out_tx.send(OutEvent::Unbind(port)).await.expect("Should send unbind");
+                Some(())
+            }
+            pkt = self.in_rx.recv() => {
+                let pkt = pkt?;
+                let src = pkt.local_port;
+                if let Some(socket_tx) = self.sockets.get(&src) {
+                    if let Err(e) = socket_tx.try_send(pkt) {
+                        log::error!("Send to socket {} error {:?}", src, e);
+                    }
+                }
+                Some(())
+            }
+        }
+    }
+}

--- a/examples/quic-tunnel/src/vnet/socket.rs
+++ b/examples/quic-tunnel/src/vnet/socket.rs
@@ -107,6 +107,8 @@ impl AsyncUdpSocket for VirtualUdpSocket {
 
 impl Drop for VirtualUdpSocket {
     fn drop(&mut self) {
-        self.close_socket_tx.send(self.port).expect("Should send success");
+        if let Err(e) = self.close_socket_tx.send(self.port) {
+            log::error!("Failed to send close socket: {:?}", e);
+        }
     }
 }

--- a/examples/quic-tunnel/src/vnet/socket.rs
+++ b/examples/quic-tunnel/src/vnet/socket.rs
@@ -1,0 +1,112 @@
+use std::{
+    fmt::Debug,
+    io::IoSliceMut,
+    net::{SocketAddr, SocketAddrV4},
+    ops::DerefMut,
+    sync::Mutex,
+    task::{Context, Poll},
+};
+
+use quinn::{
+    udp::{EcnCodepoint, RecvMeta, Transmit, UdpState},
+    AsyncUdpSocket,
+};
+use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
+
+use super::{NetworkPkt, OutEvent};
+
+pub struct VirtualUdpSocket {
+    node_id: u32,
+    port: u16,
+    addr: SocketAddr,
+    rx: Mutex<Receiver<NetworkPkt>>,
+    tx: Sender<OutEvent>,
+    close_socket_tx: UnboundedSender<u16>,
+}
+
+impl VirtualUdpSocket {
+    pub fn new(node_id: u32, port: u16, tx: Sender<OutEvent>, rx: Receiver<NetworkPkt>, close_socket_tx: UnboundedSender<u16>) -> Self {
+        Self {
+            node_id,
+            port,
+            addr: SocketAddr::V4(SocketAddrV4::new(node_id.into(), port)),
+            rx: Mutex::new(rx),
+            tx,
+            close_socket_tx,
+        }
+    }
+}
+
+impl Debug for VirtualUdpSocket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VirtualUdpSocket").finish()
+    }
+}
+
+impl AsyncUdpSocket for VirtualUdpSocket {
+    fn poll_send(&self, _state: &UdpState, _cx: &mut Context, transmits: &[Transmit]) -> Poll<Result<usize, std::io::Error>> {
+        let mut sent = 0;
+        for transmit in transmits {
+            match transmit.destination {
+                SocketAddr::V4(addr) => {
+                    let pkt = NetworkPkt {
+                        local_port: self.port,
+                        remote: u32::from_be_bytes(addr.ip().octets()),
+                        remote_port: addr.port(),
+                        data: transmit.contents.to_vec(),
+                        meta: transmit.ecn.map(|x| x as u8).unwrap_or(0),
+                    };
+                    log::debug!("{} sending {} bytes to {}", self.addr, pkt.data.len(), addr);
+                    if self.tx.try_send(OutEvent::Pkt(pkt)).is_ok() {
+                        sent += 1;
+                    }
+                }
+                _ => {
+                    sent += 1;
+                }
+            }
+        }
+        std::task::Poll::Ready(Ok(sent))
+    }
+
+    fn poll_recv(&self, cx: &mut Context, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> Poll<std::io::Result<usize>> {
+        let mut rx = self.rx.lock().expect("should lock rx");
+        match rx.poll_recv(cx) {
+            std::task::Poll::Pending => std::task::Poll::Pending,
+            std::task::Poll::Ready(Some(pkt)) => {
+                let len = pkt.data.len();
+                if len <= bufs[0].len() {
+                    let addr = SocketAddr::V4(SocketAddrV4::new(pkt.remote.into(), pkt.remote_port));
+                    log::debug!("{} received {} bytes from {}", self.addr, len, addr);
+                    bufs[0].deref_mut()[0..len].copy_from_slice(&pkt.data);
+                    meta[0] = quinn::udp::RecvMeta {
+                        addr,
+                        len,
+                        stride: len,
+                        ecn: if pkt.meta == 0 {
+                            None
+                        } else {
+                            EcnCodepoint::from_bits(pkt.meta)
+                        },
+                        dst_ip: None,
+                    };
+                    std::task::Poll::Ready(Ok(1))
+                } else {
+                    log::warn!("Buffer too small for packet {} vs {}, dropping", len, bufs[0].len());
+                    std::task::Poll::Pending
+                }
+            }
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "Socket closed"))),
+        }
+    }
+
+    fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        Ok(self.addr)
+    }
+}
+
+impl Drop for VirtualUdpSocket {
+    fn drop(&mut self) {
+        self.close_socket_tx.send(self.port).expect("Should send success");
+    }
+}

--- a/packages/network/src/features/socket.rs
+++ b/packages/network/src/features/socket.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, VecDeque};
 use atm0s_sdn_identity::NodeId;
 use atm0s_sdn_router::RouteRule;
 
-use crate::base::{Feature, FeatureContext, FeatureControlActor, FeatureInput, FeatureOutput, FeatureSharedInput, FeatureWorker, NetOutgoingMeta};
+use crate::base::{
+    Feature, FeatureContext, FeatureControlActor, FeatureInput, FeatureOutput, FeatureSharedInput, FeatureWorker, FeatureWorkerContext, FeatureWorkerInput, FeatureWorkerOutput, GenericBuffer,
+    NetOutgoingMeta, TransportMsgHeader,
+};
 
 pub const FEATURE_ID: u8 = 7;
 pub const FEATURE_NAME: &str = "socket";
@@ -25,7 +28,11 @@ pub enum Event {
 }
 
 #[derive(Debug, Clone)]
-pub struct ToWorker;
+pub enum ToWorker {
+    BindSocket(u16, FeatureControlActor),
+    ConnectSocket(u16, NodeId, u16),
+    UnbindSocket(u16),
+}
 
 #[derive(Debug, Clone)]
 pub struct ToController;
@@ -43,17 +50,10 @@ pub struct SocketFeature {
 
 impl SocketFeature {
     fn send_to(&mut self, src: u16, dest_node: NodeId, dest_port: u16, data: Vec<u8>) {
-        if data.len() > MTU_SIZE - 4 {
-            log::warn!("[SocketFeature] SendTo failed, data too large: {}", data.len());
-            return;
+        if let Some(size) = serialize_msg(&mut self.temp, src, dest_port, &data) {
+            let meta: NetOutgoingMeta = NetOutgoingMeta::new(true, Default::default(), 0);
+            self.queue.push_back(FeatureOutput::SendRoute(RouteRule::ToNode(dest_node), meta, self.temp[..size].to_vec()));
         }
-
-        self.temp[..2].copy_from_slice(&src.to_be_bytes());
-        self.temp[2..4].copy_from_slice(&dest_port.to_be_bytes());
-        self.temp[4..(4 + data.len())].copy_from_slice(&data);
-        let meta: NetOutgoingMeta = NetOutgoingMeta::new(true, Default::default(), 0);
-        self.queue
-            .push_back(FeatureOutput::SendRoute(RouteRule::ToNode(dest_node), meta, self.temp[..(4 + data.len())].to_vec()));
     }
 }
 
@@ -79,23 +79,37 @@ impl Feature<Control, Event, ToController, ToWorker> for SocketFeature {
                         return;
                     }
                     self.sockets.insert(port, Socket { target: None, actor });
+                    self.queue.push_back(FeatureOutput::ToWorker(true, ToWorker::BindSocket(port, actor)));
                 }
                 Control::Connect(port, dest_node, dest_port) => {
                     if let Some(socket) = self.sockets.get_mut(&port) {
-                        socket.target = Some((dest_node, dest_port));
+                        if socket.actor == actor {
+                            socket.target = Some((dest_node, dest_port));
+                            self.queue.push_back(FeatureOutput::ToWorker(true, ToWorker::ConnectSocket(port, dest_node, dest_port)));
+                        } else {
+                            log::warn!("[SocketFeature] Connect failed, actor mismatch: {:?} != {:?}", socket.actor, actor);
+                        }
                     } else {
                         log::warn!("[SocketFeature] Connect failed, port not found: {}", port);
                     }
                 }
                 Control::SendTo(port, dest_node, dest_port, data) => {
-                    if dest_node == ctx.node_id {
-                        if self.sockets.contains_key(&dest_port) {
-                            self.queue.push_back(FeatureOutput::Event(actor, Event::RecvFrom(dest_port, ctx.node_id, port, data)));
+                    if let Some(socket) = self.sockets.get(&port) {
+                        if socket.actor == actor {
+                            if dest_node == ctx.node_id {
+                                if self.sockets.contains_key(&dest_port) {
+                                    self.queue.push_back(FeatureOutput::Event(actor, Event::RecvFrom(dest_port, ctx.node_id, port, data)));
+                                } else {
+                                    log::warn!("[SocketFeature] SendTo failed, port not found: {}", dest_port);
+                                }
+                            } else {
+                                self.send_to(port, dest_node, dest_port, data);
+                            }
                         } else {
-                            log::warn!("[SocketFeature] SendTo failed, port not found: {}", dest_port);
+                            log::warn!("[SocketFeature] SendTo failed, actor mismatch: {:?} != {:?}", socket.actor, actor);
                         }
                     } else {
-                        self.send_to(port, dest_node, dest_port, data);
+                        log::warn!("[SocketFeature] SendTo failed, port not found: {}", port);
                     }
                 }
                 Control::Send(port, data) => {
@@ -114,20 +128,31 @@ impl Feature<Control, Event, ToController, ToWorker> for SocketFeature {
                     }
                 }
                 Control::Unbind(port) => {
-                    if self.sockets.remove(&port).is_none() {
+                    if let Some(socket) = self.sockets.get(&port) {
+                        if socket.actor == actor {
+                            self.sockets.remove(&port);
+                            self.queue.push_back(FeatureOutput::ToWorker(true, ToWorker::UnbindSocket(port)));
+                        } else {
+                            log::warn!("[SocketFeature] Unbind failed, actor mismatch: {:?} != {:?}", socket.actor, actor);
+                        }
+                    } else {
                         log::warn!("[SocketFeature] Unbind failed, port not found: {}", port);
                     }
                 }
             },
-            FeatureInput::Net(_, meta, data) | FeatureInput::Local(meta, data) => {
+            FeatureInput::Net(_, meta, buf) | FeatureInput::Local(meta, buf) => {
                 let from_node = if let Some(source) = meta.source {
                     source
                 } else {
                     log::warn!("[SocketFeature] Recv failed, source not set");
                     return;
                 };
-                let pkt_src = u16::from_be_bytes([data[0], data[1]]);
-                let pkt_dest = u16::from_be_bytes([data[2], data[3]]);
+                let (pkt_src, pkt_dest, data) = if let Some(res) = deserialize_msg(&buf) {
+                    res
+                } else {
+                    log::warn!("[SocketFeature] Recv failed, invalid data");
+                    return;
+                };
                 if let Some(socket) = self.sockets.get(&pkt_dest) {
                     if let Some((dest_node, dest_port)) = socket.target {
                         if dest_node != from_node {
@@ -138,11 +163,9 @@ impl Feature<Control, Event, ToController, ToWorker> for SocketFeature {
                             log::warn!("[SocketFeature] Recv failed, port mismatch: {} != {}", dest_port, pkt_dest);
                             return;
                         }
-                        self.queue
-                            .push_back(FeatureOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data[4..].to_vec())));
+                        self.queue.push_back(FeatureOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data.to_vec())));
                     } else {
-                        self.queue
-                            .push_back(FeatureOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data[4..].to_vec())));
+                        self.queue.push_back(FeatureOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data.to_vec())));
                     }
                 } else {
                     log::warn!("[SocketFeature] Recv failed, port not found: {}", pkt_dest);
@@ -157,7 +180,116 @@ impl Feature<Control, Event, ToController, ToWorker> for SocketFeature {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct SocketFeatureWorker;
+pub struct SocketFeatureWorker {
+    sockets: HashMap<u16, Socket>,
+    buf: [u8; MTU_SIZE],
+}
 
-impl FeatureWorker<Control, Event, ToController, ToWorker> for SocketFeatureWorker {}
+impl SocketFeatureWorker {
+    fn process_incoming(&self, from_node: NodeId, buf: &[u8]) -> Option<FeatureWorkerOutput<'static, Control, Event, ToController>> {
+        let (pkt_src, pkt_dest, data) = deserialize_msg(&buf)?;
+        let socket = self.sockets.get(&pkt_dest)?;
+        if let Some((dest_node, dest_port)) = socket.target {
+            if dest_node != from_node {
+                log::warn!("[SocketFeature] Recv failed, node mismatch: {} != {}", dest_node, from_node);
+                return None;
+            }
+            if dest_port != pkt_dest {
+                log::warn!("[SocketFeature] Recv failed, port mismatch: {} != {}", dest_port, pkt_dest);
+                return None;
+            }
+            Some(FeatureWorkerOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data.to_vec())))
+        } else {
+            Some(FeatureWorkerOutput::Event(socket.actor, Event::RecvFrom(pkt_dest, from_node, pkt_src, data.to_vec())))
+        }
+    }
+}
+
+impl Default for SocketFeatureWorker {
+    fn default() -> Self {
+        Self {
+            sockets: HashMap::new(),
+            buf: [0; MTU_SIZE],
+        }
+    }
+}
+
+impl FeatureWorker<Control, Event, ToController, ToWorker> for SocketFeatureWorker {
+    fn on_network_raw<'a>(
+        &mut self,
+        _ctx: &mut FeatureWorkerContext,
+        _now: u64,
+        _conn: atm0s_sdn_identity::ConnId,
+        _remote: std::net::SocketAddr,
+        header: TransportMsgHeader,
+        buf: GenericBuffer<'a>,
+    ) -> Option<FeatureWorkerOutput<'a, Control, Event, ToController>> {
+        self.process_incoming(header.from_node?, &(&buf)[header.serialize_size()..])
+    }
+
+    fn on_input<'a>(&mut self, _ctx: &mut FeatureWorkerContext, _now: u64, input: FeatureWorkerInput<'a, Control, ToWorker>) -> Option<FeatureWorkerOutput<'a, Control, Event, ToController>> {
+        match input {
+            FeatureWorkerInput::FromController(_, control) => match control {
+                ToWorker::BindSocket(port, actor) => {
+                    self.sockets.insert(port, Socket { target: None, actor });
+                    None
+                }
+                ToWorker::ConnectSocket(port, dest_node, dest_port) => {
+                    if let Some(socket) = self.sockets.get_mut(&port) {
+                        socket.target = Some((dest_node, dest_port));
+                    }
+                    None
+                }
+                ToWorker::UnbindSocket(port) => {
+                    self.sockets.remove(&port);
+                    None
+                }
+            },
+            FeatureWorkerInput::Control(actor, control) => {
+                let (port, (dest_node, dest_port), data) = match control {
+                    Control::Send(port, data) => {
+                        let socket = self.sockets.get(&port)?;
+                        if actor == socket.actor {
+                            (port, socket.target?, data)
+                        } else {
+                            return None;
+                        }
+                    }
+                    Control::SendTo(port, dest_node, dest_port, data) => {
+                        let socket = self.sockets.get(&port)?;
+                        if actor == socket.actor {
+                            (port, (dest_node, dest_port), data)
+                        } else {
+                            return None;
+                        }
+                    }
+                    _ => return Some(FeatureWorkerOutput::ForwardControlToController(actor, control)),
+                };
+
+                let size = serialize_msg(&mut self.buf, port, dest_port, &data)?;
+                Some(FeatureWorkerOutput::SendRoute(RouteRule::ToNode(dest_node), Default::default(), self.buf[0..size].to_vec()))
+            }
+            FeatureWorkerInput::Local(meta, buf) | FeatureWorkerInput::Network(_, meta, buf) => self.process_incoming(meta.source?, &buf),
+            _ => None,
+        }
+    }
+}
+
+fn serialize_msg(buf: &mut [u8], src: u16, dest: u16, data: &[u8]) -> Option<usize> {
+    if data.len() > buf.len() - 4 {
+        return None;
+    }
+    buf[..2].copy_from_slice(&src.to_be_bytes());
+    buf[2..4].copy_from_slice(&dest.to_be_bytes());
+    buf[4..(4 + data.len())].copy_from_slice(&data);
+    Some(data.len() + 4)
+}
+
+fn deserialize_msg<'a>(buf: &'a [u8]) -> Option<(u16, u16, &'a [u8])> {
+    if buf.len() < 4 {
+        return None;
+    }
+    let src = u16::from_be_bytes([buf[0], buf[1]]);
+    let dest = u16::from_be_bytes([buf[2], buf[3]]);
+    Some((src, dest, &buf[4..]))
+}

--- a/packages/network/tests/feature_socket.rs
+++ b/packages/network/tests/feature_socket.rs
@@ -21,11 +21,14 @@ fn feature_socket_single_node() {
 
     sim.control(node1, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10000))));
     sim.control(node1, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10001))));
-    sim.control(node1, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4]))));
+    sim.control(
+        node1,
+        ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4], 0))),
+    );
     sim.process(10);
     assert_eq!(
         sim.pop_res(),
-        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node1, 10001, vec![1, 2, 3, 4])))))
+        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node1, 10001, vec![1, 2, 3, 4], 0)))))
     );
 }
 
@@ -48,11 +51,14 @@ fn feature_socket_two_nodes() {
     sim.control(node1, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10000))));
     sim.control(node2, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10001))));
     sim.process(10);
-    sim.control(node2, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4]))));
+    sim.control(
+        node2,
+        ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4], 0))),
+    );
     sim.process(10);
     assert_eq!(
         sim.pop_res(),
-        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node2, 10001, vec![1, 2, 3, 4])))))
+        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node2, 10001, vec![1, 2, 3, 4], 0)))))
     );
 }
 
@@ -79,10 +85,13 @@ fn feature_socket_three_nodes() {
     sim.control(node1, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10000))));
     sim.control(node3, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::Bind(10001))));
     sim.process(10);
-    sim.control(node3, ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4]))));
+    sim.control(
+        node3,
+        ExtIn::FeaturesControl(FeaturesControl::Socket(socket::Control::SendTo(10001, node1, 10000, vec![1, 2, 3, 4], 0))),
+    );
     sim.process(10);
     assert_eq!(
         sim.pop_res(),
-        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node3, 10001, vec![1, 2, 3, 4])))))
+        Some((node1, ExtOut::FeaturesEvent(FeaturesEvent::Socket(socket::Event::RecvFrom(10000, node3, 10001, vec![1, 2, 3, 4], 0)))))
     );
 }

--- a/packages/network/tests/feature_socket.rs
+++ b/packages/network/tests/feature_socket.rs
@@ -11,7 +11,6 @@ mod simulator;
 fn feature_socket_single_node() {
     let node1 = 1;
     let mut sim = NetworkSimulator::<(), (), (), ()>::new(0);
-    sim.enable_log(log::LevelFilter::Debug);
 
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
 

--- a/packages/runner/src/lib.rs
+++ b/packages/runner/src/lib.rs
@@ -2,6 +2,7 @@ pub use atm0s_sdn_identity::{ConnDirection, ConnId, NodeAddr, NodeAddrBuilder, N
 pub use atm0s_sdn_network::convert_enum;
 pub use atm0s_sdn_network::features;
 pub use atm0s_sdn_network::services;
+pub use atm0s_sdn_network::base;
 pub use sans_io_runtime;
 
 pub mod builder;

--- a/packages/runner/src/lib.rs
+++ b/packages/runner/src/lib.rs
@@ -1,8 +1,8 @@
 pub use atm0s_sdn_identity::{ConnDirection, ConnId, NodeAddr, NodeAddrBuilder, NodeId, NodeIdType, Protocol};
+pub use atm0s_sdn_network::base;
 pub use atm0s_sdn_network::convert_enum;
 pub use atm0s_sdn_network::features;
 pub use atm0s_sdn_network::services;
-pub use atm0s_sdn_network::base;
 pub use sans_io_runtime;
 
 pub mod builder;


### PR DESCRIPTION
This PR add meta field to virtual socket, which can be used for implementing ECN in UDP for QUINN library. This PR also implement a quic-tunnel sample