### PR TITLE
feat: history timeout and some logs

### DIFF
--- a/packages/core/router/src/shadow/mod.rs
+++ b/packages/core/router/src/shadow/mod.rs
@@ -14,6 +14,9 @@ pub trait ShadowRouterHistory: Send + Sync {
     /// This method will check if the broadcast message is already received or not
     /// If not received, it will cache the message and return true
     fn already_received_broadcast(&self, from: Option<NodeId>, service: u8, seq: u16) -> bool;
+
+    /// For set current time ms
+    fn set_ts(&self, now: u64);
 }
 
 #[derive(Debug, Clone)]

--- a/packages/network/src/features/socket.rs
+++ b/packages/network/src/features/socket.rs
@@ -237,16 +237,19 @@ impl FeatureWorker<Control, Event, ToController, ToWorker> for SocketFeatureWork
         match input {
             FeatureWorkerInput::FromController(_, control) => match control {
                 ToWorker::BindSocket(port, actor) => {
+                    log::info!("[SocketFeatureWorker] BindSocket: {port}");
                     self.sockets.insert(port, Socket { target: None, actor });
                     None
                 }
                 ToWorker::ConnectSocket(port, dest_node, dest_port) => {
+                    log::info!("[SocketFeatureWorker] ConnectSocket: {port} => {dest_node}:{dest_port}");
                     if let Some(socket) = self.sockets.get_mut(&port) {
                         socket.target = Some((dest_node, dest_port));
                     }
                     None
                 }
                 ToWorker::UnbindSocket(port) => {
+                    log::info!("[SocketFeatureWorker] UnbindSocket: {port}");
                     self.sockets.remove(&port);
                     None
                 }
@@ -294,6 +297,7 @@ fn serialize_msg(buf: &mut [u8], src: u16, dest: u16, data: &[u8]) -> Option<usi
 
 fn deserialize_msg<'a>(buf: &'a [u8]) -> Option<(u16, u16, &'a [u8])> {
     if buf.len() < 4 {
+        log::debug!("[SocketFeature] Invalid message length: {}, min is 4 bytes", buf.len());
         return None;
     }
     let src = u16::from_be_bytes([buf[0], buf[1]]);

--- a/packages/network/tests/simulator.rs
+++ b/packages/network/tests/simulator.rs
@@ -113,6 +113,8 @@ impl ShadowRouterHistory for SingleThreadDataWorkerHistory {
         }
         false
     }
+
+    fn set_ts(&self, _now: u64) {}
 }
 
 pub struct TestNode<SC, SE, TC, TW> {

--- a/packages/runner/src/lib.rs
+++ b/packages/runner/src/lib.rs
@@ -3,6 +3,7 @@ pub use atm0s_sdn_network::base;
 pub use atm0s_sdn_network::convert_enum;
 pub use atm0s_sdn_network::features;
 pub use atm0s_sdn_network::services;
+pub use atm0s_sdn_router::ServiceBroadcastLevel;
 pub use sans_io_runtime;
 
 pub mod builder;

--- a/packages/runner/src/tasks/data_plane/history.rs
+++ b/packages/runner/src/tasks/data_plane/history.rs
@@ -1,12 +1,18 @@
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::atomic::AtomicU64,
+};
 
 use atm0s_sdn_identity::NodeId;
 use atm0s_sdn_router::shadow::ShadowRouterHistory;
 use parking_lot::Mutex;
 
+const HISTORY_TIMEOUT_MS: u64 = 2000;
+
 #[derive(Debug, Default)]
 pub struct DataWorkerHistory {
-    queue: Mutex<Vec<(Option<NodeId>, u8, u16)>>,
+    now_ms: AtomicU64,
+    queue: Mutex<VecDeque<(u64, (Option<NodeId>, u8, u16))>>,
     map: Mutex<HashMap<(Option<NodeId>, u8, u16), bool>>,
 }
 
@@ -14,14 +20,53 @@ impl ShadowRouterHistory for DataWorkerHistory {
     fn already_received_broadcast(&self, from: Option<NodeId>, service: u8, seq: u16) -> bool {
         let mut map = self.map.lock();
         let mut queue = self.queue.lock();
+        let now_ms = self.now_ms.load(std::sync::atomic::Ordering::Relaxed);
         if map.contains_key(&(from, service, seq)) {
             return true;
         }
+
         map.insert((from, service, seq), true);
+        queue.push_back((now_ms, (from, service, seq)));
         if queue.len() > 10000 {
-            let pair = queue.remove(0);
+            let (_ts, pair) = queue.pop_front().expect("queue should not empty");
             map.remove(&pair);
         }
         false
+    }
+
+    fn set_ts(&self, now_ms: u64) {
+        self.now_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+        let mut map = self.map.lock();
+        let mut queue = self.queue.lock();
+
+        while let Some((time, key)) = queue.front() {
+            if now_ms >= *time + HISTORY_TIMEOUT_MS {
+                map.remove(key);
+                queue.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use atm0s_sdn_router::shadow::ShadowRouterHistory;
+
+    use crate::tasks::data_plane::history::HISTORY_TIMEOUT_MS;
+
+    use super::DataWorkerHistory;
+
+    #[test]
+    fn simple_work() {
+        let history = DataWorkerHistory::default();
+
+        assert_eq!(history.already_received_broadcast(Some(1), 1, 1), false);
+        assert_eq!(history.already_received_broadcast(Some(1), 1, 1), true);
+
+        //after timeout
+        history.set_ts(HISTORY_TIMEOUT_MS);
+        assert_eq!(history.already_received_broadcast(Some(1), 1, 1), false);
     }
 }

--- a/packages/runner/src/tasks/mod.rs
+++ b/packages/runner/src/tasks/mod.rs
@@ -99,6 +99,7 @@ impl<SC, SE, TC: Debug, TW: Debug> WorkerInner<SdnExtIn<SC>, SdnExtOut<SE>, SdnC
                     session: controller.session,
                     tick_ms: controller.tick_ms,
                     services: cfg.services.clone(),
+                    history: cfg.history.clone(),
                     #[cfg(feature = "vpn")]
                     vpn_tun_device: controller.vpn_tun_device,
                 })),


### PR DESCRIPTION
This PR add History timeout feature for avoiding reject broadcast message from old node when node restarted cause msg seq reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for setting the current time in network routing, enhancing time-sensitive operations.
	- Enhanced network socket operations with additional logging for better monitoring and debugging.
	- Expanded the functionality of the network runner to include a history tracking feature, improving data management and operational insight.

- **Refactor**
	- Updated internal data structures for more efficient history tracking and timestamp management.

- **Tests**
	- Added tests to validate the new history functionality in network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->