### PR TITLE
chore: auto release build standalone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: 1
- 
+
     strategy:
       matrix:
         build:
@@ -140,6 +140,10 @@ jobs:
           use-cross: ${{ matrix.cross }}
           command: build
           args: --verbose --release --package ${{ env.APP_NAME }} --target ${{ matrix.target }}
+
+      - name: Rename file
+        run: |
+          mv ./target/${{ matrix.target }}/release/${{ env.APP_NAME }} ${{ env.APP_NAME }}-${{ matrix.target }}
 
       - name: Upload Artifact to Summary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,124 @@
 name: Release
 on:
   push:
+    branches: [master]
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  APP_NAME: atm0s-sdn-standalone
+  ARTIFACT_DIR: release-builds
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  OPENSSL_STATIC: true
 
 jobs:
   build-release:
-    needs: create-release
     name: build-release
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: 1
+ 
     strategy:
       matrix:
         build:
+          - linux gnu x64
           - linux musl x64
+          - linux gnu aarch64
           - linux musl aarch64
+          # - linux gnueabihf arm
+          # - linux gnueabihf armv7
+          # - linux gnu mips
+          # - linux gnuabi64 mips64
+          # - linux gnuabi64 mips64el
+          # - linux gnu mipsel
           - macos x64
           - macos aarch64
         include:
+          - build: linux gnu x64
+            os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+            extension: ""
+            cross: false
           - build: linux musl x64
             os: ubuntu-latest
             rust: stable
             target: x86_64-unknown-linux-musl
+            extension: ""
+            cross: false
+          - build: linux gnu aarch64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-unknown-linux-gnu
+            extension: ""
+            cross: true
           - build: linux musl aarch64
             os: ubuntu-latest
             rust: stable
             target: aarch64-unknown-linux-musl
+            extension: ""
+            cross: true
+          # - build: linux gnueabihf arm
+          #   os: ubuntu-latest
+          #   rust: stable
+          #   target: arm-unknown-linux-gnueabihf
+          #   extension: ""
+          #   cross: true
+          # - build: linux gnueabihf armv7
+          #   os: ubuntu-latest
+          #   rust: stable
+          #   target: armv7-unknown-linux-gnueabihf
+          #   extension: ""
+          #   cross: true
+          # - build: linux gnu mips
+          #   os: ubuntu-latest
+          #   rust: 1.71.1
+          #   target: mips-unknown-linux-gnu
+          #   extension: ""
+          #   cross: true
+          # - build: linux gnuabi64 mips64
+          #   os: ubuntu-latest
+          #   rust: 1.71.1
+          #   target: mips64-unknown-linux-gnuabi64
+          #   extension: ""
+          #   cross: true
+          # - build: linux gnuabi64 mips64el
+          #   os: ubuntu-latest
+          #   rust: 1.71.1
+          #   target: mips64el-unknown-linux-gnuabi64
+          #   extension: ""
+          #   cross: true
+          # - build: linux gnu mipsel
+          #   os: ubuntu-latest
+          #   rust: 1.71.1
+          #   target: mipsel-unknown-linux-gnu
+          #   extension: ""
+          #   cross: true
+          # - build: linux musl aarch64
+          #   os: ubuntu-latest
+          #   rust: stable
+          #   target: aarch64-unknown-linux-musl
+          #   extension: ""
+          #   cross: true
           - build: macos x64
             os: macos-latest
             rust: stable
             target: x86_64-apple-darwin
+            extension: ""
+            cross: false
           - build: macos aarch64
             os: macos-latest
             rust: stable
             target: aarch64-apple-darwin
+            extension: ""
+            cross: true
     steps:
-      - name: Set release tag
-        run: |
-          if [ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]; then
-            echo "RELEASE_TAG=main" >> "$GITHUB_ENV"
-          else
-            echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}"  >> "$GITHUB_ENV"
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -56,82 +130,85 @@ jobs:
           override: true
           target: ${{ matrix.target }}
 
-      - name: Install musl-tools
+      - name: Install dev-tools
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y --no-install-recommends musl-tools
-  
-      # Workaround for <https://github.com/actions/virtual-environments/issues/2557>
-      - name: Switch Xcode SDK
-        if: runner.os == 'macos'
-        run: |
-          cat <<EOF >> "$GITHUB_ENV"
-          SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-          EOF
+        run: sudo apt-get install -y --no-install-recommends pkg-config musl-dev musl-tools
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          use-cross: ${{ matrix.cross }}
           command: build
-          args: --verbose --release --package examples --example manual_node --target ${{ matrix.target }}
+          args: --verbose --release --package ${{ env.APP_NAME }} --target ${{ matrix.target }}
 
-      # this breaks on aarch64 and this if conditional isn't working for some reason: TODO: investigate
-      #- name: Strip release binary
-      #  if: runner.target != 'aarch64-unknown-linux-musl' && runner.target != 'aarch64-apple-darwin'
-      #  run: strip "target/${{ matrix.target }}/release/examples/manual_node"
-
-      - name: Create checksum
-        id: make-checksum
-        working-directory: ./target/${{ matrix.target }}/release/examples
-        run: |
-          name="manual_node-${{ matrix.target }}.sha256sum"
-          if [[ "$RUNNER_OS" != "macOS" ]]; then
-            sha256sum "manual_node" > "${name}"
-          else
-            shasum -a 256 "manual_node" > "${name}"
-          fi
-          echo "::set-output name=name::${name}"
-
-      - name: Tar release
-        id: make-artifact
-        working-directory: ./target/${{ matrix.target }}/release/examples
-        run: |
-          name="manual_node-${{ matrix.target }}.tar.gz"
-          tar cvzf "${name}" "manual_node"
-          echo "::set-output name=name::${name}"
-
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Artifact to Summary
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }} 
-          asset_path: ./target/${{ matrix.target }}/release/examples/${{ steps.make-artifact.outputs.name }}
-          asset_name: manual_node-${{matrix.target}}.tar.gz
-          asset_content_type: application/octet-stream
+          name: ${{ matrix.target }}
+          path: ${{ env.APP_NAME }}-${{ matrix.target }}${{ matrix.extension }}
 
-      - name: Upload checksum
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload binaries to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }} 
-          asset_path: ./target/${{ matrix.target }}/release/examples/${{ steps.make-checksum.outputs.name }}
-          asset_name: manual_node-${{matrix.target}}.sha256sum
-          asset_content_type: text/plain
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.APP_NAME }}-${{ matrix.target }}${{ matrix.extension }}
+          asset_name: ${{ env.APP_NAME }}-${{ matrix.target }}${{ matrix.extension }}
+          tag: ${{ github.ref }}
+          overwrite: true
 
   create-release:
+    # only run if not a tags build
+    if: startsWith(github.ref, 'refs/tags/') == false
+    needs: build-release
     runs-on: ubuntu-latest
-    outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - name: create_release 
+      - uses: actions/download-artifact@v4
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: create_release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: marvinpinto/action-automatic-releases@latest
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && '' || github.ref }}
-          release_name: Release ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
-          draft: ${{ github.event_name == 'workflow_dispatch' }}
-          prerelease: false  
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ github.event_name == 'workflow_dispatch' && 'latest' || (github.ref == 'refs/heads/master' && 'latest') || github.ref }}
+          title: Build ${{ github.event_name == 'workflow_dispatch' && 'development' || github.ref }}
+          files: |
+            */*
+          prerelease: true
+
+  deploy-docker:
+    needs: build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ parking_lot = "0.12"
 env_logger = "0.11"
 clap = { version = "4.4", features = ["derive", "env"] }
 mockall = "0.12.1"
-sans-io-runtime = { git = "https://github.com/giangndm/sans-io-runtime.git", rev = "c2d0c78ae5bfa7ab9c7942a7333a21a439fc5edb"}
+sans-io-runtime = { git = "https://github.com/8xff/sans-io-runtime.git", rev = "c2d0c78ae5bfa7ab9c7942a7333a21a439fc5edb"}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04 as base
+ARG TARGETPLATFORM
+COPY . /tmp
+WORKDIR /tmp
+
+RUN echo $TARGETPLATFORM
+RUN ls -R /tmp/
+# move the binary to root based on platform
+RUN case $TARGETPLATFORM in \
+        "linux/amd64")  BUILD=x86_64-unknown-linux-gnu  ;; \
+        "linux/arm64")  BUILD=aarch64-unknown-linux-gnu  ;; \
+        *) exit 1 ;; \
+    esac; \
+    mv /tmp/$BUILD/atm0s-sdn-standalone-$BUILD /atm0s-sdn-standalone; \
+    chmod +x /atm0s-sdn-standalone
+
+FROM ubuntu:22.04
+
+COPY --from=base /atm0s-sdn-standalone /atm0s-sdn-standalone
+
+ENTRYPOINT ["/atm0s-sdn-standalone"]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bin"
+name = "atm0s-sdn-standalone"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
This PR add auto build script to github action. It is run when merge to master, or release new tags.

Output: executable files and Docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved release process with enhanced automation for creating releases and deploying Docker images.
	- Optimized Dockerfile for multi-stage builds, ensuring compatibility across different platforms.

- **Chores**
	- Updated GitHub Actions workflows to restrict pushes to the `master` branch, refine job configurations, and improve artifact handling.

- **Refactor**
	- Modified tag format and added concurrency settings in GitHub Actions to streamline CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->