### PR TITLE
fix: switch to single bind for resolve connect error with multi-addresses machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ cargo build --release
 Running first seed node as a network structure collector:
 
 ```bash
-cargo run -- --collector --local-tags demo --connect-tags demo --node-id 1 --udp-port 10001 --web-addr 0.0.0.0:3000
+cargo run -- --collector --local-tags demo --connect-tags demo --node-id 1 --bind-addr 127.0.0.1:10001 --web-addr 0.0.0.0:3000
 ```
 
 Running second nodes and join to network with seed node (you need to replace with seed node IP if it running on another device):
 
 ```bash
-cargo run -- --local-tags demo --connect-tags mode --seeds 1@/ip4/127.0.0.1/udp/10001 --node-id 2 --udp-port 10002
+cargo run -- --local-tags demo --connect-tags mode --seeds 1@/ip4/127.0.0.1/udp/10001 --node-id 2 --bind-addr 127.0.0.1:10002
 ```
 
 Same with this, we can run more nodes and connect to the network. Remember change node-id and port for not conflict with other nodes.

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -246,7 +246,7 @@ async fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     tracing_subscriber::fmt::init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, VisualNodeInfo>::new(args.node_id, args.bind_addr, args.custom_addrs);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, VisualNodeInfo>::new(args.node_id, &[args.bind_addr], args.custom_addrs);
 
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
     builder.set_manual_discovery(args.local_tags, args.connect_tags);

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -69,7 +69,7 @@ struct Args {
     password: String,
 
     /// Backend type
-    #[arg(env, short, long, default_value = "polling")]
+    #[arg(env, long, default_value = "polling")]
     backend: BackendType,
 
     /// Enable Tun-Tap interface for create a vpn network between nodes

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -57,8 +57,8 @@ struct Args {
     node_id: NodeId,
 
     /// Listen address
-    #[arg(env, short, long, default_value_t = 0)]
-    udp_port: u16,
+    #[arg(env, short, long, default_value = "127.0.0.1:10000")]
+    bind_addr: SocketAddr,
 
     /// Address of node we should connect to
     #[arg(env, short, long)]
@@ -246,7 +246,7 @@ async fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     tracing_subscriber::fmt::init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, VisualNodeInfo>::new(args.node_id, args.udp_port, args.custom_addrs);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, VisualNodeInfo>::new(args.node_id, args.bind_addr, args.custom_addrs);
 
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
     builder.set_manual_discovery(args.local_tags, args.connect_tags);

--- a/bin/start_agent.sh
+++ b/bin/start_agent.sh
@@ -1,1 +1,1 @@
-cargo run -- --local-tags vpn --connect-tags vpn --seeds $1 --node-id $2 --udp-port $3
+cargo run -- --local-tags vpn --connect-tags vpn --seeds $1 --node-id $2 --bind-addr $3

--- a/bin/start_collector.sh
+++ b/bin/start_collector.sh
@@ -1,8 +1,8 @@
 # If provided $3, it will be seeds
 if [ -n "$4" ]; then
     # $4 is defined
-    cargo run -- --collector --local-tags vpn --connect-tags vpn --node-id $1 --udp-port $2 --web-addr $3 --seeds $4
+    cargo run -- --collector --local-tags vpn --connect-tags vpn --node-id $1 --bind-addr $2 --web-addr $3 --seeds $4
 else
     # $4 is not defined
-    cargo run -- --collector --local-tags vpn --connect-tags vpn --node-id $1 --udp-port $2 --web-addr $3
+    cargo run -- --collector --local-tags vpn --connect-tags vpn --node-id $1 --bind-addr $2 --web-addr $3
 fi

--- a/packages/network/src/controller_plane/neighbours/connection.rs
+++ b/packages/network/src/controller_plane/neighbours/connection.rs
@@ -10,9 +10,12 @@ const CONNECT_TIMEOUT_MS: u64 = 30000; //we need connect more time
 const CONNECTION_TIMEOUT_MS: u64 = 10000;
 
 enum State {
-    Connecting {
+    OutgoingWait {
         at_ms: u64,
-        requester: Option<Box<dyn HandshakeRequester>>,
+        requester: Box<dyn HandshakeRequester>,
+    },
+    IncomingWait {
+        at_ms: u64,
     },
     ConnectError(NeighboursConnectError),
     ConnectTimeout,
@@ -82,10 +85,7 @@ impl NeighbourConnection {
     pub fn new_outgoing(handshake_builder: Arc<dyn HandshakeBuilder>, local: NodeId, node: NodeId, session: u64, remote: SocketAddr, now_ms: u64) -> Self {
         let requester = handshake_builder.requester();
         let handshake = requester.create_public_request().expect("Should have handshake");
-        let state = State::Connecting {
-            at_ms: now_ms,
-            requester: Some(requester),
-        };
+        let state = State::OutgoingWait { at_ms: now_ms, requester };
         Self {
             conn: ConnId::from_out(0, session),
             local,
@@ -98,7 +98,7 @@ impl NeighbourConnection {
     }
 
     pub fn new_incoming(handshake_builder: Arc<dyn HandshakeBuilder>, local: NodeId, node: NodeId, session: u64, remote: SocketAddr, now_ms: u64) -> Self {
-        let state: State = State::Connecting { at_ms: now_ms, requester: None };
+        let state: State = State::IncomingWait { at_ms: now_ms };
         Self {
             conn: ConnId::from_in(0, session),
             local,
@@ -124,7 +124,7 @@ impl NeighbourConnection {
 
     pub fn disconnect(&mut self, now_ms: u64) {
         match &mut self.state {
-            State::Connecting { .. } | State::Connected { .. } => {
+            State::OutgoingWait { .. } | State::Connected { .. } => {
                 log::info!("[NeighbourConnection] Sending disconnect request with remote {}", self.remote);
                 self.state = State::Disconnecting { at_ms: now_ms };
                 self.output.push_back(self.generate_control(
@@ -143,32 +143,33 @@ impl NeighbourConnection {
 
     pub fn on_tick(&mut self, now_ms: u64) {
         match &mut self.state {
-            State::Connecting { at_ms, requester } => {
-                if let Some(requester) = requester {
-                    if now_ms - *at_ms >= CONNECT_TIMEOUT_MS {
-                        self.state = State::ConnectTimeout;
-                        self.output.push_back(Output::Event(ConnectionEvent::ConnectTimeout));
-                        log::warn!("[NeighbourConnection] Connection timeout to {} after {} ms", self.remote, CONNECT_TIMEOUT_MS);
-                    } else if now_ms - *at_ms >= RETRY_CMD_MS {
-                        if let Ok(request_buf) = requester.create_public_request() {
-                            self.output.push_back(self.generate_control(
-                                now_ms,
-                                NeighboursControlCmds::ConnectRequest {
-                                    to: self.node,
-                                    session: self.conn.session(),
-                                    handshake: request_buf,
-                                },
-                            ));
-                            log::info!("[NeighbourConnection] Resend connect request to {}, dest_node {}", self.remote, self.node);
-                        } else {
-                            log::warn!(
-                                "[NeighbourConnection] Cannot create handshake for resending connect request to {}, dest_node {}",
-                                self.remote,
-                                self.node
-                            );
-                        }
+            State::OutgoingWait { at_ms, requester } => {
+                if now_ms - *at_ms >= CONNECT_TIMEOUT_MS {
+                    self.state = State::ConnectTimeout;
+                    self.output.push_back(Output::Event(ConnectionEvent::ConnectTimeout));
+                    log::warn!("[NeighbourConnection] Connection timeout to {} after {} ms", self.remote, CONNECT_TIMEOUT_MS);
+                } else if now_ms - *at_ms >= RETRY_CMD_MS {
+                    if let Ok(request_buf) = requester.create_public_request() {
+                        self.output.push_back(self.generate_control(
+                            now_ms,
+                            NeighboursControlCmds::ConnectRequest {
+                                to: self.node,
+                                session: self.conn.session(),
+                                handshake: request_buf,
+                            },
+                        ));
+                        log::info!("[NeighbourConnection] Resend connect request to {}, dest_node {}", self.remote, self.node);
+                    } else {
+                        log::warn!(
+                            "[NeighbourConnection] Cannot create handshake for resending connect request to {}, dest_node {}",
+                            self.remote,
+                            self.node
+                        );
                     }
                 }
+            }
+            State::IncomingWait { at_ms: _ } => {
+                // maybe we need handle timeout here
             }
             State::Connected { ping_seq, last_pong_ms, .. } => {
                 if now_ms - *last_pong_ms >= CONNECTION_TIMEOUT_MS {
@@ -199,7 +200,7 @@ impl NeighbourConnection {
                             reason: NeighboursDisconnectReason::Other,
                         },
                     ));
-                    log::info!("Resend disconnect request to {}", self.remote);
+                    log::info!("[NeighbourConnection] Resend disconnect request to {}", self.remote);
                 }
             }
             _ => {}
@@ -211,18 +212,36 @@ impl NeighbourConnection {
             NeighboursControlCmds::ConnectRequest { to, session, handshake } => {
                 let result = if self.local == to && self.node == from {
                     match &mut self.state {
-                        State::Connecting { requester, .. } => {
-                            if requester.is_none() || self.conn.session() >= session {
-                                //check if we can replace the existing connection to accept the new one
-                                if self.conn.session() >= session {
-                                    log::warn!(
-                                        "[NeighbourConnection] Conflic state from {}, local session {}, remote session {} => switch to incoming",
-                                        self.remote,
-                                        self.conn.session(),
-                                        session
-                                    );
-                                    self.switch_to_incoming(session);
+                        State::IncomingWait { at_ms } => {
+                            let mut responder = self.handshake_builder.responder();
+                            match responder.process_public_request(&handshake) {
+                                Ok((encryptor, decryptor, response)) => {
+                                    self.output.push_back(Output::Event(ConnectionEvent::Connected(encryptor, decryptor)));
+                                    self.state = State::Connected {
+                                        last_pong_ms: now_ms,
+                                        ping_seq: 0,
+                                        stats: ConnectionStats { rtt_ms: INIT_RTT_MS },
+                                        handshake: Some((handshake, response.clone(), session)),
+                                    };
+                                    log::info!("[NeighbourConnection] Connected to {} as incoming conn", self.remote);
+                                    Ok(response)
                                 }
+                                Err(_) => {
+                                    log::error!("[NeighbourConnection] Invalid connect request from {}", self.remote);
+                                    Err(NeighboursConnectError::InvalidData)
+                                }
+                            }
+                        }
+                        State::OutgoingWait { requester, .. } => {
+                            if self.conn.session() >= session {
+                                //check if we can replace the existing connection to accept the new one
+                                log::warn!(
+                                    "[NeighbourConnection] Conflic state from {}, local session {}, remote session {} => switch to incoming",
+                                    self.remote,
+                                    self.conn.session(),
+                                    session
+                                );
+                                self.switch_to_incoming(session);
 
                                 let mut responder = self.handshake_builder.responder();
                                 match responder.process_public_request(&handshake) {
@@ -234,10 +253,13 @@ impl NeighbourConnection {
                                             stats: ConnectionStats { rtt_ms: INIT_RTT_MS },
                                             handshake: Some((handshake, response.clone(), session)),
                                         };
-                                        log::info!("Connected to {} as incoming conn", self.remote);
+                                        log::info!("[NeighbourConnection] Connected to {} as incoming conn", self.remote);
                                         Ok(response)
                                     }
-                                    Err(_) => Err(NeighboursConnectError::InvalidData),
+                                    Err(_) => {
+                                        log::error!("[NeighbourConnection] Invalid connect request from {}", self.remote);
+                                        Err(NeighboursConnectError::InvalidData)
+                                    }
                                 }
                             } else {
                                 log::warn!(
@@ -289,9 +311,9 @@ impl NeighbourConnection {
             }
             NeighboursControlCmds::ConnectResponse { session, result } => {
                 if session == self.conn.session() {
-                    if let State::Connecting { requester, .. } = &mut self.state {
+                    if let State::OutgoingWait { requester, .. } = &mut self.state {
                         match (requester, result) {
-                            (Some(requester), Ok(handshake_res)) => match requester.process_public_response(&handshake_res) {
+                            (requester, Ok(handshake_res)) => match requester.process_public_response(&handshake_res) {
                                 Ok((encryptor, decryptor)) => {
                                     self.output.push_back(Output::Event(ConnectionEvent::Connected(encryptor, decryptor)));
                                     self.state = State::Connected {
@@ -308,16 +330,9 @@ impl NeighbourConnection {
                                     self.output.push_back(Output::Event(ConnectionEvent::ConnectError(NeighboursConnectError::InvalidData)));
                                 }
                             },
-                            (None, Ok(_)) => {
-                                log::warn!("Connect response from  {} but wrong state, handshake requester not found", self.remote);
-                                self.state = State::ConnectError(NeighboursConnectError::InvalidData);
-                                self.output.push_back(Output::Event(ConnectionEvent::ConnectError(NeighboursConnectError::InvalidData)));
-                            }
                             (_, Err(err)) => {
                                 // We don't need to fire error here, we will reconnect utils timeout
                                 log::warn!("Connect response error from {}: {:?}", self.remote, err);
-                                // self.state = State::ConnectError(err);
-                                //self.output.push_back(Output::Event(ConnectionEvent::ConnectError(err)));
                             }
                         }
                     } else {

--- a/packages/runner/Cargo.toml
+++ b/packages/runner/Cargo.toml
@@ -22,7 +22,6 @@ parking_lot.workspace = true
 log.workspace = true
 serde.workspace = true
 bincode.workspace = true
-local-ip-address = "0.6.1"
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/packages/runner/examples/simple_kv.rs
+++ b/packages/runner/examples/simple_kv.rs
@@ -10,7 +10,7 @@ use atm0s_sdn_network::{
 use clap::{Parser, ValueEnum};
 use sans_io_runtime::backend::{PollBackend, PollingBackend};
 use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,

--- a/packages/runner/examples/simple_kv.rs
+++ b/packages/runner/examples/simple_kv.rs
@@ -10,6 +10,7 @@ use atm0s_sdn_network::{
 use clap::{Parser, ValueEnum};
 use sans_io_runtime::backend::{PollBackend, PollingBackend};
 use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -35,7 +36,7 @@ struct Args {
 
     /// Listen address
     #[arg(short, long)]
-    udp_port: u16,
+    bind_addr: SocketAddr,
 
     /// Address of node we should connect to
     #[arg(short, long)]
@@ -78,7 +79,7 @@ fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     env_logger::builder().format_timestamp_millis().init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.udp_port, vec![]);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.bind_addr, vec![]);
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
 
     for seed in args.seeds {

--- a/packages/runner/examples/simple_kv.rs
+++ b/packages/runner/examples/simple_kv.rs
@@ -79,7 +79,7 @@ fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     env_logger::builder().format_timestamp_millis().init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.bind_addr, vec![]);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, &[args.bind_addr], vec![]);
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
 
     for seed in args.seeds {

--- a/packages/runner/examples/simple_node.rs
+++ b/packages/runner/examples/simple_node.rs
@@ -29,7 +29,7 @@ struct Args {
 
     /// Listen address
     #[arg(short, long)]
-    udp_port: u16,
+    bind_addr: SocketAddr,
 
     /// Address of node we should connect to
     #[arg(short, long)]
@@ -76,7 +76,7 @@ fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     env_logger::builder().format_timestamp_millis().init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.udp_port, args.custom_addrs);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.bind_addr, args.custom_addrs);
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
 
     builder.set_manual_discovery(args.local_tags, args.connect_tags);

--- a/packages/runner/examples/simple_node.rs
+++ b/packages/runner/examples/simple_node.rs
@@ -76,7 +76,7 @@ fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     env_logger::builder().format_timestamp_millis().init();
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, args.bind_addr, args.custom_addrs);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(args.node_id, &[args.bind_addr], args.custom_addrs);
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
 
     builder.set_manual_discovery(args.local_tags, args.connect_tags);

--- a/packages/runner/src/builder.rs
+++ b/packages/runner/src/builder.rs
@@ -53,6 +53,7 @@ where
     TW: 'static + Clone + Send + Sync,
 {
     pub fn new(node_id: NodeId, bind_addr: SocketAddr, custom_ip: Vec<SocketAddr>) -> Self {
+        assert!(!bind_addr.ip().is_unspecified(), "Don't support unspecified bind_addr");
         let node_addr = generate_node_addr(node_id, bind_addr, custom_ip);
         log::info!("Created node on addr {}", node_addr);
 

--- a/packages/runner/tests/feature_dht_kv.rs
+++ b/packages/runner/tests/feature_dht_kv.rs
@@ -49,7 +49,7 @@ fn expect_event(node: &mut SdnController<(), SC, SE, TC, TW>, expected: dht_kv::
 }
 
 fn build_node(node_id: NodeId, udp_port: u16) -> (SdnController<(), SC, SE, TC, TW>, NodeAddr) {
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(node_id, SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, udp_port)), vec![]);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(node_id, &[SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, udp_port))], vec![]);
     builder.set_authorization(StaticKeyAuthorization::new("password-here"));
     let node_addr = builder.node_addr();
     let node_info = node_id;

--- a/packages/runner/tests/feature_dht_kv.rs
+++ b/packages/runner/tests/feature_dht_kv.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    time::Duration,
+};
 
 use atm0s_sdn::{
     features::{
@@ -46,7 +49,7 @@ fn expect_event(node: &mut SdnController<(), SC, SE, TC, TW>, expected: dht_kv::
 }
 
 fn build_node(node_id: NodeId, udp_port: u16) -> (SdnController<(), SC, SE, TC, TW>, NodeAddr) {
-    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(node_id, udp_port, vec![]);
+    let mut builder = SdnBuilder::<(), SC, SE, TC, TW, UserInfo>::new(node_id, SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, udp_port)), vec![]);
     builder.set_authorization(StaticKeyAuthorization::new("password-here"));
     let node_addr = builder.node_addr();
     let node_info = node_id;


### PR DESCRIPTION
This PR add config bind-addr by specific SocketAddr instead of port only. This is for resolving connect error with some machine with multiple ip addresses.

In future we should support multiple bind addresses,  this is tracked with separated issue: https://github.com/8xFF/atm0s-sdn/issues/171