### PR TITLE
fix: avoid send wrong hops with router-sync local services

### DIFF
--- a/packages/core/router/src/core/registry.rs
+++ b/packages/core/router/src/core/registry.rs
@@ -131,7 +131,7 @@ impl Registry {
         let mut res = vec![];
         for i in 0..=255 {
             if self.local_destinations[i as usize] {
-                res.push((i, Metric::new(0, vec![self.node_id], REGISTRY_LOCAL_BW)));
+                res.push((i, Metric::new(0, vec![], REGISTRY_LOCAL_BW)));
             } else {
                 let dest: &RegistryDest = &self.remote_destinations[i as usize];
                 if !dest.is_empty() {
@@ -204,7 +204,7 @@ mod tests {
         assert_eq!(registry.next(1, &[]), Some(ServiceDestination::Local));
 
         let sync = registry.sync_for(node1);
-        assert_eq!(sync.0, vec![(1, Metric::new(0, vec![0], REGISTRY_LOCAL_BW))]);
+        assert_eq!(sync.0, vec![(1, Metric::new(0, vec![], REGISTRY_LOCAL_BW))]);
     }
 
     #[test]

--- a/packages/core/router/src/core/router.rs
+++ b/packages/core/router/src/core/router.rs
@@ -254,7 +254,7 @@ mod tests {
         let (node_e, conn_e, mut router_e) = create_router(0x05);
         let (node_f, conn_f, mut router_f) = create_router(0x06);
 
-        let metric_registry_local = Metric::new(0, vec![node_a], REGISTRY_LOCAL_BW);
+        let metric_registry_local = Metric::new(0, vec![], REGISTRY_LOCAL_BW);
 
         router_a.register_service(1);
         router_a.set_direct(conn_d, Metric::new(1, vec![node_d], 1));


### PR DESCRIPTION
Currently it sent wrong hops like: `Node1: { service1: { hops: [node1] }}`. Instead of that it must send `Node1: { service1: { hops: [] }}` because it is local service