### PR TITLE
feat: discovery node by service broadcast

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,13 +1,14 @@
 #![allow(clippy::bool_assert_comparison)]
 
-use atm0s_sdn::features::{router_sync, FeaturesEvent};
+use atm0s_sdn::features::{neighbours, router_sync, FeaturesControl, FeaturesEvent};
 use atm0s_sdn::secure::StaticKeyAuthorization;
+use atm0s_sdn::services::manual2_discovery::AdvertiseTarget;
 use atm0s_sdn::services::visualization;
 use atm0s_sdn::{
     sans_io_runtime::backend::{PollBackend, PollingBackend},
     services::visualization::ConnectionInfo,
 };
-use atm0s_sdn::{NodeAddr, NodeId, SdnControllerUtils};
+use atm0s_sdn::{NodeAddr, NodeId, SdnControllerUtils, SdnExtIn, ServiceBroadcastLevel};
 use atm0s_sdn::{SdnBuilder, SdnExtOut, SdnOwner};
 use clap::{Parser, ValueEnum};
 use futures_util::{SinkExt, StreamExt};
@@ -88,14 +89,6 @@ struct Args {
     /// Custom IP
     #[arg(env, long)]
     custom_addrs: Vec<SocketAddr>,
-
-    /// Local tags
-    #[arg(env, long)]
-    local_tags: Vec<String>,
-
-    /// Connect tags
-    #[arg(env, long)]
-    connect_tags: Vec<String>,
 
     /// Web server addr
     #[arg(env, long, default_value = "0.0.0.0:3000")]
@@ -271,22 +264,11 @@ async fn main() {
     let mut shutdown_wait = 0;
     let args = Args::parse();
     tracing_subscriber::fmt::init();
-    let addrs = local_ip_address::list_afinet_netifas()
-        .expect("Should have list interfaces")
-        .into_iter()
-        .filter(|(_, ip)| {
-            if ip.is_unspecified() || ip.is_multicast() {
-                false
-            } else {
-                std::net::UdpSocket::bind(SocketAddr::new(*ip, 0)).is_ok()
-            }
-        })
-        .map(|(_name, ip)| SocketAddr::new(ip, args.udp_port))
-        .collect::<Vec<_>>();
+    let addrs = vec![SocketAddr::new(local_ip_address::local_ip().expect("Should have list interfaces"), args.udp_port)];
     let mut builder = SdnBuilder::<(), SC, SE, TC, TW, VisualNodeInfo>::new(args.node_id, &addrs, args.custom_addrs);
 
     builder.set_authorization(StaticKeyAuthorization::new(&args.password));
-    builder.set_manual_discovery(args.local_tags, args.connect_tags);
+    builder.set_manual2_discovery(vec![AdvertiseTarget::new(2.into(), ServiceBroadcastLevel::Global)], 1000);
 
     if args.vpn {
         builder.enable_vpn();
@@ -294,15 +276,15 @@ async fn main() {
 
     builder.set_visualization_collector(args.collector);
 
-    for seed in args.seeds {
-        builder.add_seed(seed);
-    }
-
     let node_info = VisualNodeInfo { uptime: 0 };
     let mut controller = match args.backend {
         BackendType::Poll => builder.build::<PollBackend<SdnOwner, 128, 128>>(args.workers, node_info),
         BackendType::Polling => builder.build::<PollingBackend<SdnOwner, 128, 128>>(args.workers, node_info),
     };
+
+    for seed in args.seeds.iter() {
+        controller.send_to(0, SdnExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(seed.clone(), true))));
+    }
 
     let (dump_tx, mut dump_rx) = unbounded_channel::<oneshot::Sender<serde_json::Value>>();
     let ctx = Arc::new(Mutex::new(WebsocketCtx::new()));
@@ -368,18 +350,24 @@ async fn main() {
                         ctx.lock().await.del_node(node);
                     }
                 },
-                SdnExtOut::FeaturesEvent(_, event) => {
-                    if let FeaturesEvent::RouterSync(event) = event {
-                        match event {
-                            router_sync::Event::DumpRouter(value) => {
-                                let json = serde_json::to_value(value).expect("should convert json");
-                                while let Some(v) = wait_dump_router.pop() {
-                                    let _ = v.send(json.clone());
-                                }
+                SdnExtOut::FeaturesEvent(_, event) => match event {
+                    FeaturesEvent::RouterSync(event) => match event {
+                        router_sync::Event::DumpRouter(value) => {
+                            let json = serde_json::to_value(value).expect("should convert json");
+                            while let Some(v) = wait_dump_router.pop() {
+                                let _ = v.send(json.clone());
+                            }
+                        }
+                    },
+                    FeaturesEvent::Neighbours(event) => {
+                        if let neighbours::Event::SeedAddressNeeded = event {
+                            for seed in args.seeds.iter() {
+                                controller.send_to(0, SdnExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(seed.clone(), true))));
                             }
                         }
                     }
-                }
+                    _ => {}
+                },
             }
         }
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -254,6 +254,7 @@ async fn dump_router(ctx: Data<&UnboundedSender<oneshot::Sender<serde_json::Valu
     }
 }
 
+#[allow(clippy::collapsible_match)]
 #[tokio::main]
 async fn main() {
     if std::env::var_os("RUST_LOG").is_none() {

--- a/packages/core/router/src/core/registry.rs
+++ b/packages/core/router/src/core/registry.rs
@@ -96,7 +96,7 @@ impl Registry {
 
     pub fn apply_sync(&mut self, conn: ConnId, metric: Metric, sync: RegistrySync) {
         let src = metric.over_node();
-        log::debug!("apply sync from {} -> {}, sync {:?}", src, self.node_id, sync.0);
+        log::debug!("[Registry] apply sync from {} -> {}, sync {:?}", src, self.node_id, sync.0);
         let mut cached: HashMap<u8, Metric> = HashMap::new();
         for (index, s_metric) in sync.0 {
             cached.insert(index, s_metric.add(&metric));

--- a/packages/network/src/base/control.rs
+++ b/packages/network/src/base/control.rs
@@ -12,6 +12,7 @@ pub enum NeighboursConnectError {
     InvalidSignature,
     InvalidData,
     InvalidState,
+    Timeout,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/packages/network/src/base/mod.rs
+++ b/packages/network/src/base/mod.rs
@@ -28,6 +28,8 @@ pub struct ConnectionStats {
 
 #[derive(Debug, Clone)]
 pub enum ConnectionEvent {
+    Connecting(ConnectionCtx),
+    ConnectError(ConnectionCtx, NeighboursConnectError),
     Connected(ConnectionCtx, SecureContext),
     Stats(ConnectionCtx, ConnectionStats),
     Disconnected(ConnectionCtx),

--- a/packages/network/src/controller_plane.rs
+++ b/packages/network/src/controller_plane.rs
@@ -117,12 +117,6 @@ where
 
     pub fn on_event(&mut self, now_ms: u64, event: Input<UserData, SC, SE, TC>) {
         match event {
-            Input::Ext(ExtIn::ConnectTo(addr)) => {
-                self.neighbours.input(&mut self.switcher).on_input(now_ms, neighbours::Input::ConnectTo(addr));
-            }
-            Input::Ext(ExtIn::DisconnectFrom(node)) => {
-                self.neighbours.input(&mut self.switcher).on_input(now_ms, neighbours::Input::DisconnectFrom(node));
-            }
             Input::Ext(ExtIn::FeaturesControl(userdata, control)) => {
                 self.features.input(&mut self.switcher).on_input(
                     &self.feature_ctx,
@@ -200,6 +194,8 @@ where
                     .input(&mut self.switcher)
                     .on_shared_input(&self.service_ctx, now_ms, ServiceSharedInput::Connection(event.clone()));
                 match event {
+                    ConnectionEvent::Connecting(_ctx) => {}
+                    ConnectionEvent::ConnectError(_ctx, _err) => {}
                     ConnectionEvent::Connected(ctx, secure) => self.queue.push_back(Output::Event(LogicEvent::Pin(ctx.conn, ctx.node, ctx.pair, secure))),
                     ConnectionEvent::Stats(_ctx, _stats) => {}
                     ConnectionEvent::Disconnected(ctx) => self.queue.push_back(Output::Event(LogicEvent::UnPin(ctx.conn))),

--- a/packages/network/src/data_plane.rs
+++ b/packages/network/src/data_plane.rs
@@ -165,12 +165,6 @@ where
     pub fn on_event(&mut self, now_ms: u64, event: Input<UserData, SC, SE, TW>) {
         match event {
             Input::Ext(ext) => match ext {
-                ExtIn::ConnectTo(_remote) => {
-                    panic!("ConnectTo is not supported")
-                }
-                ExtIn::DisconnectFrom(_node) => {
-                    panic!("DisconnectFrom is not supported")
-                }
                 ExtIn::FeaturesControl(userdata, control) => {
                     let feature: Features = control.to_feature();
                     let actor = FeatureControlActor::Worker(self.worker_id, userdata);
@@ -300,6 +294,7 @@ where
                     }
                 }
                 if !pairs.is_empty() {
+                    log::debug!("Incoming broadcast from: {pair} forward to: {pairs:?}");
                     if let Some(out) = self.build_send_to_multi_from_mut(now_ms, pairs, buf) {
                         self.queue.push_back(out.into());
                     }

--- a/packages/network/src/features/dht_kv/client/map.rs
+++ b/packages/network/src/features/dht_kv/client/map.rs
@@ -387,7 +387,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
                 match &mut self.sub_state {
                     SubState::Subscribing { id: sub_id, .. } => {
                         if *sub_id == id {
-                            log::debug!("[ClientMap] Received SubOk with id {}, switched to Subscribed with sync_ts {}", id, now);
+                            log::info!("[ClientMap] Received SubOk with id {}, switched to Subscribed with sync_ts {}", id, now);
                             self.sub_state = SubState::Subscribed { id, remote, sync_ts: now };
                             self.fire_event(MapEvent::OnRelaySelected(remote.0));
                         } else {
@@ -403,7 +403,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
                             *sync_ts = now;
 
                             if old_locked.0 != remote.0 {
-                                log::debug!(
+                                log::info!(
                                     "[ClientMap] Received SubOk with id {}, in Subscribed from new remote {} with sync_ts {} => resync all local slots now",
                                     id,
                                     remote.0,
@@ -415,7 +415,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
                                 log::debug!("[ClientMap] Received SubOk with id {} from same remote {} vs {}", id, locked.0, remote.0);
                             }
                         } else {
-                            log::debug!("[ClientMap] Received SubOk with id {} but current id is {}", id, sub_id);
+                            log::warn!("[ClientMap] Received SubOk with id {} but current id is {}", id, sub_id);
                         }
                     }
                     _ => {
@@ -427,7 +427,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
             ServerMapEvent::UnsubOk(id) => {
                 if let SubState::Unsubscribing { id: sub_id, remote: locked, .. } = &self.sub_state {
                     if *sub_id == id && (*locked).unwrap_or(remote) == remote {
-                        log::debug!("[ClientMap] Received UnsubOk with id {}, switched to NotSub", id);
+                        log::info!("[ClientMap] Received UnsubOk with id {}, switched to NotSub", id);
                         self.sub_state = SubState::NotSub;
                     } else {
                         log::warn!(

--- a/packages/network/src/features/dht_kv/client/map.rs
+++ b/packages/network/src/features/dht_kv/client/map.rs
@@ -387,7 +387,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
                 match &mut self.sub_state {
                     SubState::Subscribing { id: sub_id, .. } => {
                         if *sub_id == id {
-                            log::info!("[ClientMap] Received SubOk with id {}, switched to Subscribed with sync_ts {}", id, now);
+                            log::debug!("[ClientMap] Received SubOk with id {}, switched to Subscribed with sync_ts {}", id, now);
                             self.sub_state = SubState::Subscribed { id, remote, sync_ts: now };
                             self.fire_event(MapEvent::OnRelaySelected(remote.0));
                         } else {
@@ -403,7 +403,7 @@ impl<UserData: Eq + Copy + Debug> LocalMap<UserData> {
                             *sync_ts = now;
 
                             if old_locked.0 != remote.0 {
-                                log::info!(
+                                log::debug!(
                                     "[ClientMap] Received SubOk with id {}, in Subscribed from new remote {} with sync_ts {} => resync all local slots now",
                                     id,
                                     remote.0,

--- a/packages/network/src/lib.rs
+++ b/packages/network/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::bool_assert_comparison)]
 
-use atm0s_sdn_identity::{ConnId, NodeAddr, NodeId};
+use atm0s_sdn_identity::{ConnId, NodeId};
 use atm0s_sdn_router::RouteRule;
 use base::{FeatureControlActor, NeighboursControl, NetIncomingMeta, NetOutgoingMeta, SecureContext, ServiceControlActor, ServiceId};
 use data_plane::NetPair;
@@ -19,8 +19,6 @@ pub mod worker;
 
 #[derive(Debug, Clone)]
 pub enum ExtIn<UserData, ServicesControl> {
-    ConnectTo(NodeAddr),
-    DisconnectFrom(NodeId),
     FeaturesControl(UserData, FeaturesControl),
     ServicesControl(ServiceId, UserData, ServicesControl),
 }

--- a/packages/network/src/services/manual2_discovery.rs
+++ b/packages/network/src/services/manual2_discovery.rs
@@ -64,7 +64,7 @@ impl<UserData, SC, SE, TC, TW> Manual2DiscoveryService<UserData, SC, SE, TC, TW>
         Self {
             node_addr,
             targets,
-            queue: VecDeque::from_iter([data_control(DataControl::DataListen(DATA_PORT))].into_iter()),
+            queue: VecDeque::from_iter([data_control(DataControl::DataListen(DATA_PORT))]),
             remote_nodes: Default::default(),
             shutdown: false,
             broadcast_seq: 0,

--- a/packages/network/src/services/manual2_discovery.rs
+++ b/packages/network/src/services/manual2_discovery.rs
@@ -1,0 +1,273 @@
+//! This service implement a node discovery using service-broadcast feature
+//! Each node will be have a list of broadcast service target and broadcast level.
+//! Example: (Service 1, Global), (Service 2, Inner Zone)
+//!
+//! Each nodes based on configured above list will be try to broadcast it address in order to allow other nodes to connect to it.
+//!
+//! The origin idea of this method is for avoiding network partition. By rely on service broadcast, each node can adverise its address to other nodes even if network is incomplete state.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fmt::Debug,
+};
+
+use atm0s_sdn_identity::{ConnId, NodeAddr, NodeId};
+use atm0s_sdn_router::{RouteRule, ServiceBroadcastLevel};
+use sans_io_runtime::collections::DynamicDeque;
+
+use crate::{
+    base::{
+        ConnectionEvent, NetOutgoingMeta, Service, ServiceBuilder, ServiceCtx, ServiceId, ServiceInput, ServiceOutput, ServiceSharedInput, ServiceWorker, ServiceWorkerCtx, ServiceWorkerInput,
+        ServiceWorkerOutput, Ttl,
+    },
+    features::{data::Control as DataControl, neighbours::Control as NeighbourControl, FeaturesControl, FeaturesEvent},
+};
+
+const DATA_PORT: u16 = 2;
+pub const SERVICE_ID: u8 = 2;
+pub const SERVICE_NAME: &str = "manual2_discovery";
+
+fn neighbour_control<UserData, SE, TW>(c: NeighbourControl) -> ServiceOutput<UserData, FeaturesControl, SE, TW> {
+    ServiceOutput::FeatureControl(FeaturesControl::Neighbours(c))
+}
+
+fn data_control<UserData, SE, TW>(c: DataControl) -> ServiceOutput<UserData, FeaturesControl, SE, TW> {
+    ServiceOutput::FeatureControl(FeaturesControl::Data(c))
+}
+
+#[derive(Debug, Clone)]
+pub struct AdvertiseTarget {
+    pub service: ServiceId,
+    pub level: ServiceBroadcastLevel,
+}
+
+impl AdvertiseTarget {
+    pub fn new(service: ServiceId, level: ServiceBroadcastLevel) -> Self {
+        Self { service, level }
+    }
+}
+
+pub struct Manual2DiscoveryService<UserData, SC, SE, TC, TW> {
+    node_addr: NodeAddr,
+    targets: Vec<AdvertiseTarget>,
+    queue: VecDeque<ServiceOutput<UserData, FeaturesControl, SE, TW>>,
+    remote_nodes: HashMap<NodeId, HashSet<ConnId>>,
+    shutdown: bool,
+    broadcast_seq: u16,
+    broadcast_interval: u64,
+    last_broadcast: u64,
+    _tmp: std::marker::PhantomData<(SC, TC, TW)>,
+}
+
+impl<UserData, SC, SE, TC, TW> Manual2DiscoveryService<UserData, SC, SE, TC, TW> {
+    pub fn new(node_addr: NodeAddr, targets: Vec<AdvertiseTarget>, interval: u64) -> Self {
+        Self {
+            node_addr,
+            targets,
+            queue: VecDeque::from_iter([data_control(DataControl::DataListen(DATA_PORT))].into_iter()),
+            remote_nodes: Default::default(),
+            shutdown: false,
+            broadcast_seq: 0,
+            broadcast_interval: interval,
+            last_broadcast: 0,
+            _tmp: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<UserData, SC, SE, TC: Debug, TW: Debug> Service<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC, TW> for Manual2DiscoveryService<UserData, SC, SE, TC, TW> {
+    fn is_service_empty(&self) -> bool {
+        self.shutdown && self.queue.is_empty()
+    }
+
+    fn service_id(&self) -> u8 {
+        SERVICE_ID
+    }
+
+    fn service_name(&self) -> &str {
+        SERVICE_NAME
+    }
+
+    fn on_shared_input<'a>(&mut self, _ctx: &ServiceCtx, now: u64, input: ServiceSharedInput) {
+        match input {
+            ServiceSharedInput::Tick(_) => {
+                if now >= self.last_broadcast + self.broadcast_interval {
+                    self.last_broadcast = now;
+                    self.broadcast_seq = self.broadcast_seq.wrapping_add(1);
+                    for target in &self.targets {
+                        log::debug!("[Manual2DiscoveryService] advertise to service {} with level {:?}", target.service, target.level);
+                        self.queue.push_back(data_control(DataControl::DataSendRule(
+                            DATA_PORT,
+                            RouteRule::ToServices(*target.service, target.level, self.broadcast_seq),
+                            NetOutgoingMeta::new(true, Ttl::default(), 0, true),
+                            self.node_addr.to_vec(),
+                        )));
+                    }
+                }
+            }
+            ServiceSharedInput::Connection(connection_event) => match connection_event {
+                ConnectionEvent::Connecting(connection_ctx) => {
+                    self.remote_nodes.entry(connection_ctx.node).or_default().insert(connection_ctx.conn);
+                }
+                ConnectionEvent::ConnectError(connection_ctx, _neighbours_connect_error) => {
+                    let entry = self.remote_nodes.entry(connection_ctx.node).or_default();
+                    entry.remove(&connection_ctx.conn);
+                    if entry.is_empty() {
+                        log::warn!("[Manual2DiscoveryService] Node {} connect failed all connections => remove", connection_ctx.node);
+                        self.remote_nodes.remove(&connection_ctx.node);
+                    }
+                }
+                ConnectionEvent::Connected(_connection_ctx, _secure_context) => {}
+                ConnectionEvent::Stats(_connection_ctx, _connection_stats) => {}
+                ConnectionEvent::Disconnected(connection_ctx) => {
+                    let entry = self.remote_nodes.entry(connection_ctx.node).or_default();
+                    entry.remove(&connection_ctx.conn);
+                    if entry.is_empty() {
+                        self.remote_nodes.remove(&connection_ctx.node);
+                        log::info!("[Manual2DiscoveryService] Node {} disconnected all connections => remove", connection_ctx.node);
+                    }
+                }
+            },
+        }
+    }
+
+    fn on_input(&mut self, _ctx: &ServiceCtx, _now: u64, input: ServiceInput<UserData, FeaturesEvent, SC, TC>) {
+        match input {
+            ServiceInput::Control(_, _) => {}
+            ServiceInput::FromWorker(_) => {}
+            ServiceInput::FeatureEvent(event) => {
+                if let FeaturesEvent::Data(event) = event {
+                    match event {
+                        crate::features::data::Event::Pong(_, _) => todo!(),
+                        crate::features::data::Event::Recv(port, meta, data) => {
+                            // ignore other port
+                            if port != DATA_PORT {
+                                log::warn!("[Manual2DiscoveryService] Recv from other port => ignore");
+                                return;
+                            }
+                            // ignore unsecure
+                            if !meta.secure {
+                                log::warn!("[Manual2DiscoveryService] Recv from unsecure node => ignore");
+                                return;
+                            }
+                            if let Some(source) = meta.source {
+                                // ignore self
+                                if source == self.node_addr.node_id() {
+                                    return;
+                                }
+                                // ignore already connected
+                                if self.remote_nodes.contains_key(&source) {
+                                    log::warn!("[Manual2DiscoveryService] Recv from already connected node {source} => ignore");
+                                    return;
+                                }
+                            } else {
+                                // ignore anonymous
+                                log::warn!("[Manual2DiscoveryService] Recv from anonymous node => ignore");
+                                return;
+                            }
+                            if let Some(addr) = NodeAddr::from_vec(&data) {
+                                log::info!("[Manual2DiscoveryService] Node {} advertised => try connect {addr:?}", addr.node_id());
+                                self.queue.push_back(neighbour_control(NeighbourControl::ConnectTo(addr, false)));
+                            } else {
+                                log::warn!("[Manual2DiscoveryService] Node {:?} advertised invalid address => ignore", meta.source);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn on_shutdown(&mut self, _ctx: &ServiceCtx, _now: u64) {
+        log::info!("[Manual2DiscoveryService] Shutdown");
+        self.shutdown = true;
+    }
+
+    fn pop_output2(&mut self, _now: u64) -> Option<ServiceOutput<UserData, FeaturesControl, SE, TW>> {
+        self.queue.pop_front()
+    }
+}
+
+pub struct Manual2DiscoveryServiceWorker<UserData, SC, SE, TC> {
+    queue: DynamicDeque<ServiceWorkerOutput<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC>, 8>,
+    shutdown: bool,
+}
+
+impl<UserData, SC, SE, TC, TW> ServiceWorker<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC, TW> for Manual2DiscoveryServiceWorker<UserData, SC, SE, TC> {
+    fn is_service_empty(&self) -> bool {
+        self.shutdown && self.queue.is_empty()
+    }
+
+    fn service_id(&self) -> u8 {
+        SERVICE_ID
+    }
+
+    fn service_name(&self) -> &str {
+        SERVICE_NAME
+    }
+
+    fn on_tick(&mut self, _ctx: &ServiceWorkerCtx, _now: u64, _tick_count: u64) {}
+
+    fn on_input(&mut self, _ctx: &ServiceWorkerCtx, _now: u64, input: ServiceWorkerInput<UserData, FeaturesEvent, SC, TW>) {
+        match input {
+            ServiceWorkerInput::Control(actor, control) => self.queue.push_back(ServiceWorkerOutput::ForwardControlToController(actor, control)),
+            ServiceWorkerInput::FeatureEvent(event) => self.queue.push_back(ServiceWorkerOutput::ForwardFeatureEventToController(event)),
+            ServiceWorkerInput::FromController(_) => {}
+        }
+    }
+
+    fn on_shutdown(&mut self, _ctx: &ServiceWorkerCtx, _now: u64) {
+        log::info!("[Manual2DiscoveryServiceWorker] Shutdown");
+        self.shutdown = true;
+    }
+
+    fn pop_output2(&mut self, _now: u64) -> Option<ServiceWorkerOutput<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC>> {
+        self.queue.pop_front()
+    }
+}
+
+pub struct Manual2DiscoveryServiceBuilder<UserData, SC, SE, TC, TW> {
+    _tmp: std::marker::PhantomData<(UserData, SC, SE, TC, TW)>,
+    node_addr: NodeAddr,
+    targets: Vec<AdvertiseTarget>,
+    interval: u64,
+}
+
+impl<UserData, SC, SE, TC, TW> Manual2DiscoveryServiceBuilder<UserData, SC, SE, TC, TW> {
+    pub fn new(node_addr: NodeAddr, targets: Vec<AdvertiseTarget>, interval: u64) -> Self {
+        Self {
+            _tmp: std::marker::PhantomData,
+            node_addr,
+            targets,
+            interval,
+        }
+    }
+}
+
+impl<UserData, SC, SE, TC, TW> ServiceBuilder<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC, TW> for Manual2DiscoveryServiceBuilder<UserData, SC, SE, TC, TW>
+where
+    UserData: 'static + Debug + Send + Sync,
+    SC: 'static + Debug + Send + Sync,
+    SE: 'static + Debug + Send + Sync,
+    TC: 'static + Debug + Send + Sync,
+    TW: 'static + Debug + Send + Sync,
+{
+    fn service_id(&self) -> u8 {
+        SERVICE_ID
+    }
+
+    fn service_name(&self) -> &str {
+        SERVICE_NAME
+    }
+
+    fn create(&self) -> Box<dyn Service<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC, TW>> {
+        Box::new(Manual2DiscoveryService::new(self.node_addr.clone(), self.targets.clone(), self.interval))
+    }
+
+    fn create_worker(&self) -> Box<dyn ServiceWorker<UserData, FeaturesControl, FeaturesEvent, SC, SE, TC, TW>> {
+        Box::new(Manual2DiscoveryServiceWorker {
+            queue: Default::default(),
+            shutdown: false,
+        })
+    }
+}

--- a/packages/network/src/services/manual2_discovery.rs
+++ b/packages/network/src/services/manual2_discovery.rs
@@ -142,12 +142,12 @@ impl<UserData, SC, SE, TC: Debug, TW: Debug> Service<UserData, FeaturesControl, 
                         crate::features::data::Event::Recv(port, meta, data) => {
                             // ignore other port
                             if port != DATA_PORT {
-                                log::warn!("[Manual2DiscoveryService] Recv from other port => ignore");
+                                log::warn!("[Manual2DiscoveryService] recv from other port => ignore");
                                 return;
                             }
                             // ignore unsecure
                             if !meta.secure {
-                                log::warn!("[Manual2DiscoveryService] Recv from unsecure node => ignore");
+                                log::warn!("[Manual2DiscoveryService] recv from unsecure node => ignore");
                                 return;
                             }
                             if let Some(source) = meta.source {
@@ -157,19 +157,19 @@ impl<UserData, SC, SE, TC: Debug, TW: Debug> Service<UserData, FeaturesControl, 
                                 }
                                 // ignore already connected
                                 if self.remote_nodes.contains_key(&source) {
-                                    log::warn!("[Manual2DiscoveryService] Recv from already connected node {source} => ignore");
+                                    log::debug!("[Manual2DiscoveryService] recv from already connected node {source} => ignore");
                                     return;
                                 }
                             } else {
                                 // ignore anonymous
-                                log::warn!("[Manual2DiscoveryService] Recv from anonymous node => ignore");
+                                log::warn!("[Manual2DiscoveryService] recv from anonymous node => ignore");
                                 return;
                             }
                             if let Some(addr) = NodeAddr::from_vec(&data) {
-                                log::info!("[Manual2DiscoveryService] Node {} advertised => try connect {addr:?}", addr.node_id());
+                                log::info!("[Manual2DiscoveryService] node {} advertised => try connect {addr:?}", addr.node_id());
                                 self.queue.push_back(neighbour_control(NeighbourControl::ConnectTo(addr, false)));
                             } else {
-                                log::warn!("[Manual2DiscoveryService] Node {:?} advertised invalid address => ignore", meta.source);
+                                log::warn!("[Manual2DiscoveryService] node {:?} advertised invalid address => ignore", meta.source);
                             }
                         }
                     }

--- a/packages/network/src/services/mod.rs
+++ b/packages/network/src/services/mod.rs
@@ -1,2 +1,3 @@
+pub mod manual2_discovery;
 pub mod manual_discovery;
 pub mod visualization;

--- a/packages/network/src/services/visualization.rs
+++ b/packages/network/src/services/visualization.rs
@@ -149,6 +149,8 @@ where
                     )));
                 }
             }
+            ServiceSharedInput::Connection(ConnectionEvent::Connecting(_ctx)) => {}
+            ServiceSharedInput::Connection(ConnectionEvent::ConnectError(_ctx, _err)) => {}
             ServiceSharedInput::Connection(ConnectionEvent::Connected(ctx, _)) => {
                 log::info!("[Visualization] New connection from {} to {}, set default rtt_ms to 1000ms", ctx.pair, ctx.node);
                 self.conns.insert(

--- a/packages/network/tests/feature_alias.rs
+++ b/packages/network/tests/feature_alias.rs
@@ -4,7 +4,7 @@ use atm0s_sdn_network::{
     base::{Service, ServiceBuilder, ServiceCtx, ServiceInput, ServiceOutput, ServiceSharedInput, ServiceWorker, ServiceWorkerCtx, ServiceWorkerInput, ServiceWorkerOutput},
     features::{
         alias::{self, FoundLocation},
-        FeaturesControl, FeaturesEvent,
+        neighbours, FeaturesControl, FeaturesEvent,
     },
     ExtIn, ExtOut,
 };
@@ -151,7 +151,7 @@ fn feature_alias_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![Arc::new(MockServiceBuilder)]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![Arc::new(MockServiceBuilder)]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -187,7 +187,7 @@ fn feature_alias_three_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![Arc::new(MockServiceBuilder)]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![Arc::new(MockServiceBuilder)]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -202,7 +202,7 @@ fn feature_alias_three_nodes() {
     sim.process(10);
 
     let addr3 = sim.add_node(TestNode::new(node3, 1236, vec![Arc::new(MockServiceBuilder)]));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {

--- a/packages/network/tests/feature_dht_kv.rs
+++ b/packages/network/tests/feature_dht_kv.rs
@@ -1,7 +1,7 @@
 use atm0s_sdn_network::{
     features::{
         dht_kv::{Control, Event, Key, Map, MapControl, MapEvent},
-        FeaturesControl, FeaturesEvent,
+        neighbours, FeaturesControl, FeaturesEvent,
     },
     ExtIn, ExtOut,
 };
@@ -75,7 +75,7 @@ fn feature_dht_kv_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -106,7 +106,7 @@ fn feature_dht_kv_two_nodes_sub_after() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -139,7 +139,7 @@ fn feature_dht_kv_move_key_other_relay() {
 
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -163,7 +163,7 @@ fn feature_dht_kv_move_key_other_relay() {
 
     log::info!("add new node3 => data should move to node3");
     let addr3 = sim.add_node(TestNode::new(node3, 1235, vec![]));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync table
     for _i in 0..4 {

--- a/packages/network/tests/feature_neighbours.rs
+++ b/packages/network/tests/feature_neighbours.rs
@@ -20,7 +20,7 @@ fn feature_neighbours_two_nodes() {
     sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
     sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -44,6 +44,78 @@ fn feature_neighbours_two_nodes() {
             (
                 node2,
                 ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Connected(node1, ConnId::from_in(0, 1000))))
+            ),
+        ]
+    );
+}
+
+#[test]
+fn feature_neighbours_request_seed_node() {
+    let node1 = 1;
+    let node2 = 2;
+    let mut sim = NetworkSimulator::<(), (), (), ()>::new(0);
+
+    let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
+    let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
+
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
+
+    // connect to node2 as seed node
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, true))));
+
+    // For sync
+    for _i in 0..4 {
+        sim.process(500);
+    }
+
+    let mut out = vec![];
+    while let Some((node, out_event)) = sim.pop_res() {
+        out.push((node, out_event));
+    }
+
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(
+        out,
+        vec![
+            (
+                node1,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Connected(node2, ConnId::from_out(0, 1000))))
+            ),
+            (
+                node2,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Connected(node1, ConnId::from_in(0, 1000))))
+            ),
+        ]
+    );
+
+    // simulate node2 disconnect from node1
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::DisconnectFrom(node1))));
+
+    // For sync
+    for _i in 0..4 {
+        sim.process(500);
+    }
+
+    let mut out = vec![];
+    while let Some((node, out_event)) = sim.pop_res() {
+        out.push((node, out_event));
+    }
+
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(
+        out,
+        vec![
+            (
+                node1,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Disconnected(node2, ConnId::from_out(0, 1000))))
+            ),
+            (node1, ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::SeedAddressNeeded))),
+            (
+                node2,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Disconnected(node1, ConnId::from_in(0, 1000))))
             ),
         ]
     );

--- a/packages/network/tests/feature_pubsub.rs
+++ b/packages/network/tests/feature_pubsub.rs
@@ -1,5 +1,6 @@
 use atm0s_sdn_network::{
     features::{
+        neighbours,
         pubsub::{ChannelControl, ChannelEvent, ChannelId, Control, Event, Feedback},
         FeaturesControl, FeaturesEvent,
     },
@@ -113,7 +114,7 @@ fn feature_pubsub_manual_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -141,7 +142,7 @@ fn feature_pubsub_auto_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -184,8 +185,8 @@ fn feature_pubsub_manual_three_nodes() {
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
     let addr3 = sim.add_node(TestNode::new(node3, 1236, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {
@@ -215,8 +216,8 @@ fn feature_pubsub_auto_three_nodes() {
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
     let addr3 = sim.add_node(TestNode::new(node3, 1236, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {
@@ -260,8 +261,8 @@ fn feature_pubsub_auto_three_nodes_sub_after_start() {
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
     let addr3 = sim.add_node(TestNode::new(node3, 1236, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {

--- a/packages/network/tests/feature_router_sync.rs
+++ b/packages/network/tests/feature_router_sync.rs
@@ -5,7 +5,7 @@ use atm0s_sdn_network::{
         NetIncomingMeta, NetOutgoingMeta, Service, ServiceBuilder, ServiceCtx, ServiceInput, ServiceOutput, ServiceSharedInput, ServiceWorker, ServiceWorkerCtx, ServiceWorkerInput,
         ServiceWorkerOutput,
     },
-    features::{data, FeaturesControl, FeaturesEvent},
+    features::{data, neighbours, FeaturesControl, FeaturesEvent},
     ExtIn, ExtOut,
 };
 use atm0s_sdn_router::RouteRule;
@@ -140,7 +140,7 @@ fn feature_router_sync_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     sim.process(500);
@@ -162,8 +162,8 @@ fn feature_router_sync_three_nodes() {
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
     let addr3 = sim.add_node(TestNode::new(node3, 1236, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {

--- a/packages/network/tests/feature_socket.rs
+++ b/packages/network/tests/feature_socket.rs
@@ -1,5 +1,5 @@
 use atm0s_sdn_network::{
-    features::{socket, FeaturesControl, FeaturesEvent},
+    features::{neighbours, socket, FeaturesControl, FeaturesEvent},
     ExtIn, ExtOut,
 };
 
@@ -44,7 +44,7 @@ fn feature_socket_two_nodes() {
     let _addr1 = sim.add_node(TestNode::new(node1, 1234, vec![]));
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync
     for _i in 0..4 {
@@ -80,8 +80,8 @@ fn feature_socket_three_nodes() {
     let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![]));
     let addr3 = sim.add_node(TestNode::new(node3, 1233, vec![]));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {

--- a/packages/network/tests/service_manual2_discovery.rs
+++ b/packages/network/tests/service_manual2_discovery.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use atm0s_sdn_identity::ConnId;
+use atm0s_sdn_network::{
+    features::{neighbours, FeaturesControl, FeaturesEvent},
+    services::manual2_discovery::{AdvertiseTarget, Manual2DiscoveryServiceBuilder},
+    ExtIn, ExtOut,
+};
+use atm0s_sdn_router::ServiceBroadcastLevel;
+
+use crate::simulator::{build_addr, NetworkSimulator, TestNode};
+
+mod simulator;
+
+/// We create 3node with init connection: A -- B -- C
+/// A advertise it address to global then C should connect to A
+#[test]
+fn service_manual_discovery2_three_nodes() {
+    let node1 = 1;
+    let node2 = 2;
+    let node3 = 3;
+    let mut sim = NetworkSimulator::<(), (), (), ()>::new(0);
+
+    let _addr1 = sim.add_node(TestNode::new(
+        node1,
+        1234,
+        vec![Arc::new(Manual2DiscoveryServiceBuilder::new(
+            build_addr(node1),
+            vec![AdvertiseTarget {
+                service: 2.into(),
+                level: ServiceBroadcastLevel::Global,
+            }],
+            100,
+        ))],
+    ));
+    let addr2 = sim.add_node(TestNode::new(node2, 1235, vec![Arc::new(Manual2DiscoveryServiceBuilder::new(build_addr(node2), vec![], 100))]));
+    let _addr3 = sim.add_node(TestNode::new(node3, 1236, vec![Arc::new(Manual2DiscoveryServiceBuilder::new(build_addr(node3), vec![], 100))]));
+
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
+
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2.clone(), false))));
+    sim.control(node3, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+
+    // For sync
+    for _i in 0..10 {
+        sim.process(500);
+    }
+
+    let mut out = vec![];
+    while let Some((node, out_event)) = sim.pop_res() {
+        out.push((node, out_event));
+    }
+
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(
+        out,
+        vec![
+            (
+                node1,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Connected(node2, ConnId::from_out(0, 1000))))
+            ),
+            (
+                node1,
+                ExtOut::FeaturesEvent((), FeaturesEvent::Neighbours(neighbours::Event::Connected(node3, ConnId::from_in(0, 3005))))
+            ),
+        ]
+    );
+}

--- a/packages/network/tests/service_manual_discovery.rs
+++ b/packages/network/tests/service_manual_discovery.rs
@@ -32,8 +32,8 @@ fn service_manual_discovery_three_nodes() {
 
     sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::Sub)));
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync
     for _i in 0..4 {

--- a/packages/network/tests/service_visualization.rs
+++ b/packages/network/tests/service_visualization.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use atm0s_sdn_identity::{ConnId, NodeId};
 use atm0s_sdn_network::{
+    features::{neighbours, FeaturesControl},
     services::visualization::{self, ConnectionInfo, Control, Event, VisualizationServiceBuilder},
     ExtIn, ExtOut,
 };
@@ -62,7 +63,7 @@ fn service_visualization_simple() {
         ))
     );
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
 
     // For sync route table and snapshot process
     for _i in 0..5 {
@@ -117,8 +118,8 @@ fn service_visualization_multi_collectors() {
         ))
     );
 
-    sim.control(node1, ExtIn::ConnectTo(addr2));
-    sim.control(node2, ExtIn::ConnectTo(addr3));
+    sim.control(node1, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr2, false))));
+    sim.control(node2, ExtIn::FeaturesControl((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(addr3, false))));
 
     // For sync route table and snapshot process
     for _i in 0..5 {
@@ -152,8 +153,8 @@ fn service_visualization_multi_collectors() {
         node1_events,
         vec![
             node_changed(node1, node1_info.clone(), &[(node2, ConnId::from_out(0, 1000))]),
-            node_changed(node2, node2_info.clone(), &[(node3, ConnId::from_out(0, 1000)), (node1, ConnId::from_in(0, 1000))]),
-            node_changed(node3, node3_info.clone(), &[(node2, ConnId::from_in(0, 1000))]),
+            node_changed(node2, node2_info.clone(), &[(node1, ConnId::from_in(0, 1000)), (node3, ConnId::from_out(0, 2000))]),
+            node_changed(node3, node3_info.clone(), &[(node2, ConnId::from_in(0, 2000))]),
         ]
     );
 
@@ -161,8 +162,8 @@ fn service_visualization_multi_collectors() {
         node2_events,
         vec![
             node_changed(node1, node1_info, &[(node2, ConnId::from_out(0, 1000))]),
-            node_changed(node2, node2_info, &[(node3, ConnId::from_out(0, 1000)), (node1, ConnId::from_in(0, 1000))]),
-            node_changed(node3, node3_info, &[(node2, ConnId::from_in(0, 1000))]),
+            node_changed(node2, node2_info, &[(node1, ConnId::from_in(0, 1000)), (node3, ConnId::from_out(0, 2000))]),
+            node_changed(node3, node3_info, &[(node2, ConnId::from_in(0, 2000))]),
         ]
     );
 }

--- a/packages/network/tests/simulator.rs
+++ b/packages/network/tests/simulator.rs
@@ -135,7 +135,7 @@ impl<SC: Debug, SE: Debug, TC: Debug, TW: Debug> TestNode<SC, SE, TC, TW> {
         let _log = AutoContext::new(node_id);
         let authorization: Arc<StaticKeyAuthorization> = Arc::new(StaticKeyAuthorization::new("demo-key"));
         let handshake_builder = Arc::new(HandshakeBuilderXDA);
-        let random = Box::new(StepRng::new(1000, 5));
+        let random = Box::new(StepRng::new(node_id as u64 * 1_000, 5));
         let history = Arc::new(SingleThreadDataWorkerHistory::default());
         Self {
             node_id,

--- a/packages/runner/src/lib.rs
+++ b/packages/runner/src/lib.rs
@@ -28,7 +28,6 @@ pub use time::{TimePivot, TimeTicker};
 pub use worker_inner::{SdnChannel, SdnController, SdnEvent, SdnExtIn, SdnExtOut, SdnOwner};
 
 pub trait SdnControllerUtils<UserData, SC> {
-    fn connect_to(&mut self, addr: NodeAddr);
     fn feature_control(&mut self, userdata: UserData, cmd: FeaturesControl);
     fn service_control(&mut self, service: ServiceId, userdata: UserData, cmd: SC);
 }
@@ -41,9 +40,6 @@ impl<
         TW: 'static + Send + Sync + Clone,
     > SdnControllerUtils<UserData, SC> for SdnController<UserData, SC, SE, TC, TW>
 {
-    fn connect_to(&mut self, addr: NodeAddr) {
-        self.send_to(0, SdnExtIn::ConnectTo(addr));
-    }
     fn feature_control(&mut self, userdata: UserData, cmd: FeaturesControl) {
         self.send_to(0, SdnExtIn::FeaturesControl(userdata, cmd));
     }

--- a/packages/runner/tests/feature_dht_kv.rs
+++ b/packages/runner/tests/feature_dht_kv.rs
@@ -6,7 +6,7 @@ use std::{
 use atm0s_sdn::{
     features::{
         dht_kv::{self, MapControl, MapEvent},
-        FeaturesControl, FeaturesEvent,
+        neighbours, FeaturesControl, FeaturesEvent,
     },
     secure::StaticKeyAuthorization,
     services::visualization,
@@ -80,7 +80,7 @@ fn test_two_nodes() {
     let (mut node1, node_addr1) = build_node(node1_id, 11000);
     let (mut node2, _node_addr2) = build_node(node2_id, 11001);
 
-    node2.connect_to(node_addr1);
+    node2.feature_control((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(node_addr1, false)));
 
     process(&mut [&mut node1, &mut node2], 100);
     log::info!("sending map cmd Sub");
@@ -103,8 +103,8 @@ fn test_three_nodes() {
     let (mut node2, node_addr2) = build_node(node2_id, 12001);
     let (mut node3, _node_addr3) = build_node(node3_id, 12002);
 
-    node2.connect_to(node_addr1);
-    node3.connect_to(node_addr2);
+    node2.feature_control((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(node_addr1, false)));
+    node3.feature_control((), FeaturesControl::Neighbours(neighbours::Control::ConnectTo(node_addr2, false)));
 
     process(&mut [&mut node1, &mut node2, &mut node3], 100);
     log::info!("sending map cmd Sub");


### PR DESCRIPTION
This PR introduce a new discovery mechanism by use service broadcast feature, this call Manual2Discovery.

For active new discovery, simple use builder then set list of destination target we need to advertise to

```rust
builder.set_manual2_discovery(
        vec![
            // for broadcast to other console nodes
            AdvertiseTarget::new(visualization::SERVICE_ID.into(), ServiceBroadcastLevel::Global),
            // for broadcast to all gateway nodes
            AdvertiseTarget::new(media_server_gateway::STORE_SERVICE_ID.into(), ServiceBroadcastLevel::Global),
        ],
        1000,
    );
```