### PR TITLE
fixed: router don't clear service router info after node disconnect

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -14,9 +14,11 @@ signal-hook = "0.3.17"
 log.workspace = true
 clap.workspace = true
 serde.workspace = true
-atm0s-sdn = { path = "../packages/runner", version = "0.2.5", features = ["vpn"] }
+atm0s-sdn = { path = "../packages/runner", version = "0.2.5", features = [
+    "vpn",
+] }
 tokio = { version = "1", features = ["full"] }
-poem = { version = "3.0", features = ["embed", "static-files", "websocket"] }
+poem = { version = "3", features = ["embed", "static-files", "websocket"] }
 rust-embed = { version = "8.2", optional = true }
 
 futures-util = "0.3"

--- a/packages/network/src/base/feature.rs
+++ b/packages/network/src/base/feature.rs
@@ -211,7 +211,7 @@ impl<UserData, Control, Event, ToController> FeatureWorkerOutput<UserData, Contr
 
 pub struct FeatureWorkerContext {
     pub node_id: NodeId,
-    pub router: ShadowRouter<NetPair>,
+    pub router: ShadowRouter<ConnId, NetPair>,
 }
 
 pub trait FeatureWorker<UserData, SdkControl, SdkEvent, ToController, ToWorker>: TaskSwitcherChild<FeatureWorkerOutput<UserData, SdkControl, SdkEvent, ToController>> {

--- a/packages/network/src/base/service.rs
+++ b/packages/network/src/base/service.rs
@@ -68,7 +68,6 @@ impl<UserData, FeaturesControl, FeaturesEvent, ServiceControl, ServiceEvent, ToC
 }
 
 /// Second part is Worker, which is running inside each data plane workers.
-
 pub enum ServiceWorkerInput<UserData, FeaturesEvent, ServiceControl, ToWorker> {
     Control(ServiceControlActor<UserData>, ServiceControl),
     FromController(ToWorker),

--- a/packages/network/src/data_plane/connection.rs
+++ b/packages/network/src/data_plane/connection.rs
@@ -27,7 +27,7 @@ impl DataPlaneConnection {
 
     /// This will encrypt without first byte, which is used for TransportMsgHeader meta
     pub fn encrypt_if_need(&mut self, now: u64, buf: &mut Buffer) -> Option<()> {
-        if buf.len() < 1 {
+        if buf.is_empty() {
             return None;
         }
         if !TransportMsgHeader::is_secure(buf[0]) {
@@ -42,7 +42,7 @@ impl DataPlaneConnection {
 
     /// This will encrypt without first byte, which is used for TransportMsgHeader meta
     pub fn decrypt_if_need(&mut self, now: u64, buf: &mut Buffer) -> Option<()> {
-        if buf.len() < 1 {
+        if buf.is_empty() {
             return None;
         }
         if !TransportMsgHeader::is_secure(buf[0]) {

--- a/packages/network/src/secure/encryption/x25519_dalek_aes.rs
+++ b/packages/network/src/secure/encryption/x25519_dalek_aes.rs
@@ -156,7 +156,7 @@ impl Decryptor for DecryptorXDA {
 
 struct BufferMut2<'a>(&'a mut BufferMut);
 
-impl<'a> Buffer for BufferMut2<'a> {
+impl Buffer for BufferMut2<'_> {
     fn extend_from_slice(&mut self, other: &[u8]) -> aes_gcm::aead::Result<()> {
         self.0.push_back(other);
         Ok(())
@@ -175,13 +175,13 @@ impl<'a> Buffer for BufferMut2<'a> {
     }
 }
 
-impl<'a> AsRef<[u8]> for BufferMut2<'a> {
+impl AsRef<[u8]> for BufferMut2<'_> {
     fn as_ref(&self) -> &[u8] {
         self.0.deref()
     }
 }
 
-impl<'a> AsMut<[u8]> for BufferMut2<'a> {
+impl AsMut<[u8]> for BufferMut2<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.deref_mut()
     }

--- a/packages/network/src/worker.rs
+++ b/packages/network/src/worker.rs
@@ -213,7 +213,7 @@ where
     }
 
     fn is_empty(&self) -> bool {
-        self.shutdown && self.controller.as_ref().map_or(true, |c| c.is_empty()) && self.data.is_empty()
+        self.shutdown && self.controller.as_ref().is_none_or(|c| c.is_empty()) && self.data.is_empty()
     }
 
     fn pop_output(&mut self, now: u64) -> Option<SdnWorkerOutput<UserData, SC, SE, TC, TW>> {

--- a/packages/network/src/worker.rs
+++ b/packages/network/src/worker.rs
@@ -80,7 +80,7 @@ where
     }
 
     pub fn is_empty(&self) -> bool {
-        self.shutdown && self.controller.as_ref().map_or(true, |c| c.is_empty()) && self.data.is_empty()
+        self.shutdown && self.controller.as_ref().is_none_or(|c| c.is_empty()) && self.data.is_empty()
     }
 
     pub fn on_tick(&mut self, now_ms: u64) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR fix serious issue with router sync.

In case of network disconnect, router_sync receives a Disconnect event then it remove connection from conns hashmap first, but it cause DelServiceRemote never fires because self.conns already removed connection before.

https://github.com/8xFF/atm0s-sdn/blob/a6f4df739a97ff3a304e3355b3e619eb5ff91413/packages/network/src/features/router_sync.rs#L182