### PR TITLE
fixed: dht-kv missed clear remote slots on unsub

### DIFF
--- a/packages/network/src/features/dht_kv/client.rs
+++ b/packages/network/src/features/dht_kv/client.rs
@@ -57,6 +57,7 @@ impl<UserData: Eq + Debug + Copy> LocalStorage<UserData> {
         }
 
         for key in to_remove {
+            log::info!("[DhtKvClient] remove old map: {}", key);
             self.maps.remove(&key);
         }
 


### PR DESCRIPTION
This PR fixes an issue in dht-kv when processing remote UnsubOk or UnsubTimeout. It previously missed clearing remote slots, causing the map to remain uncleared after creation.